### PR TITLE
Text matching of MemberExpression nodes now includes the property name

### DIFF
--- a/docs/rules/immutable-data.md
+++ b/docs/rules/immutable-data.md
@@ -71,15 +71,30 @@ For example:
 
 ```js
 {
-  // Ignore all mutations directly on top-level objects that are prefixed with "mutable_".
-  "ignorePattern": "mutable_*"
+  // Ignore all reassigning to object properties that are prefixed with "mutable_".
+  "ignorePattern": "**.mutable_*"
 }
 ```
 
 ```js
 {
-  // Ignore all mutations directly on all objects, and any of their deeply nested properties, where that object is prefixed with "mutable_".
+  // Ignore all shallow mutations made to object properties that are prefixed with "mutable_".
+  "ignorePattern": "**.mutable_*.*"
+}
+```
+
+```js
+{
+  // Ignore all deep mutations made to object properties that are prefixed with "mutable_".
+  "ignorePattern": "**.mutable_*.*.**"
+}
+```
+
+```js
+{
+  // Ignore all deep mutations and reassigning to object properties that are prefixed with "mutable_".
   "ignorePattern": "**.mutable_*.**"
+  // This is the same as `"ignorePattern": ["**.mutable_*", "**.mutable_*.*.**"]`
 }
 ```
 
@@ -88,4 +103,4 @@ For example:
 The following wildcards can be used when specifing a pattern:
 
 `**` - Match any depth (including zero). Can only be used as a full accessor.
-`*` - When used as a full accessor, match the next accessor. When used as part of an accessor, match any characters.
+`*` - When used as a full accessor, match the next accessor (there must be one). When used as part of an accessor, match any characters.

--- a/tests/common/ignore-options.test.ts
+++ b/tests/common/ignore-options.test.ts
@@ -18,102 +18,111 @@ describe("option: ignore", () => {
       // Exact match.
       {
         code: dedent`
-          mutable = 0;
-          mutable.foo = 0;
-          mutable[0] = 0;`,
+          mutable = 0;`,
         options: [true, { ignoreAccessorPattern: "mutable" }]
+      },
+      {
+        code: dedent`
+          mutable.foo = 0;`,
+        options: [true, { ignoreAccessorPattern: "mutable.foo" }]
       },
       {
         code: dedent`
           x = 0;
           xxx_mutable_xxx = 0;
           mutable.foo.bar = 0;
-          mutable.foo[0] = 0;`,
+          mutable.foo[0] = 0;
+          mutable.foo["foo-bar"] = 0;`,
         options: [false, { ignoreAccessorPattern: "mutable" }]
       },
       // Prefix match.
       {
         code: dedent`
           mutable_ = 0;
-          mutable_xxx = 0;
-          mutable_xxx.foo = 0;
-          mutable_xxx[0] = 0;`,
+          mutable_xxx = 0;`,
         options: [true, { ignoreAccessorPattern: "mutable_*" }]
       },
       {
         code: dedent`
           x = 0;
           xxx_mutable_xxx = 0;
-          mutable_xxx.foo.bar = 0;
-          mutable_xxx.foo[0] = 0;`,
+          mutable_xxx.foo = 0;
+          mutable_xxx[0] = 0;
+          mutable_xxx["foo-bar"] = 0;`,
         options: [false, { ignoreAccessorPattern: "mutable_*" }]
       },
       // Suffix match.
       {
         code: dedent`
           _mutable = 0;
-          xxx_mutable = 0;
-          xxx_mutable.foo = 0;
-          xxx_mutable[0] = 0;`,
+          xxx_mutable = 0;`,
         options: [true, { ignoreAccessorPattern: "*_mutable" }]
       },
       {
         code: dedent`
           x = 0;
           xxx_mutable_xxx = 0;
-          xxx_mutable.foo.bar = 0;
-          xxx_mutable.foo[0] = 0;`,
+          xxx_mutable.foo = 0;
+          xxx_mutable[0] = 0;
+          xxx_mutable["foo-bar"] = 0;`,
         options: [false, { ignoreAccessorPattern: "*_mutable" }]
       },
       // Middle match.
       {
         code: dedent`
-          xxx_mutable_xxx.foo = 0;
-          xxx_mutable_xxx[0] = 0;
           xxx_mutable_xxx = 0;`,
         options: [true, { ignoreAccessorPattern: "*_mutable_*" }]
       },
       {
         code: dedent`
           x = 0;
-          xxx_mutable_xxx.foo.bar = 0;
-          xxx_mutable_xxx.foo[0] = 0;`,
+          xxx_mutable_xxx.foo = 0;
+          xxx_mutable_xxx[0] = 0;
+          xxx_mutable_xxx["foo-bar"] = 0;`,
         options: [false, { ignoreAccessorPattern: "*_mutable_*" }]
       },
-      // Mutable self.
+      // Mutable properties.
       {
         code: dedent`
-          mutable_xxx.foo.bar = 0;
-          mutable_xxx.foo[0] = 0;`,
+          mutable_xxx.foo = 0;
+          mutable_xxx[0] = 0;
+          mutable_xxx["foo-bar"] = 0;`,
         options: [true, { ignoreAccessorPattern: "mutable_*.*" }]
       },
       {
         code: dedent`
-          mutable_xxx.foo.bar.baz = 0;
-          mutable_xxx.foo = 0;
-          mutable_xxx[0] = 0;`,
+          mutable_xxx = 0;
+          mutable_xxx.foo.bar = 0;
+          mutable_xxx.foo[0] = 0;
+          mutable_xxx.foo["foo-bar"] = 0;`,
         options: [false, { ignoreAccessorPattern: "mutable_*.*" }]
       },
       // Mutable deep properties.
       {
         code: dedent`
-          mutable_xxx.foo.bar.baz[0] = 0;
-          mutable_xxx.foo.bar.baz = [0, 1, 2];
-          mutable_xxx.foo.bar = 0;`,
-        options: [true, { ignoreAccessorPattern: "mutable_*.**.*" }]
+          mutable_xxx.foo.bar[0] = 0;
+          mutable_xxx.foo.bar["foo-bar"] = 0;
+          mutable_xxx.foo.bar = [0, 1, 2];
+          mutable_xxx.foo = 0;
+          mutable_xxx[0] = 0;
+          mutable_xxx["foo-bar"] = 0;`,
+        options: [true, { ignoreAccessorPattern: "mutable_*.*.**" }]
       },
       {
         code: dedent`
-          mutable_xxx.foo = 0;`,
-        options: [false, { ignoreAccessorPattern: "mutable_*.**.*" }]
+          mutable_xxx = 0;`,
+        options: [false, { ignoreAccessorPattern: "mutable_*.*.**" }]
       },
-      // Mutable deep properties and mutable self.
+      // Mutable deep properties and container.
       {
         code: dedent`
-          mutable_xxx.foo.bar.baz[0] = 0;
-          mutable_xxx.foo.bar.baz = [0, 1, 2];
-          mutable_xxx.foo.bar = 0;
-          mutable_xxx.foo = 0;`,
+          mutable_xxx.foo.bar[0] = 0;
+          mutable_xxx.foo.bar["foo-bar"] = 0;
+          mutable_xxx.foo.bar = [0, 1, 2];
+          mutable_xxx.foo = 0;
+          mutable_xxx[0] = 0;
+          mutable_xxx["foo-bar"] = 0;
+          mutable_xxx = 0;`,
         options: [true, { ignoreAccessorPattern: "mutable_*.**" }]
       }
     ];
@@ -153,16 +162,13 @@ describe("option: ignore", () => {
         code: dedent`
           _mutable = 0;
           xxx_mutable = 0;
-          xxx_mutable.foo = 0;
-          xxx_mutable[0] = 0;`,
+          foo.xxx_mutable = 0;`,
         options: [true, { ignorePattern: "_mutable$" }]
       },
       // Middle match.
       {
         code: dedent`
-          mutable = 0;
-          mutable.foo = 0;
-          mutable[0] = 0;`,
+          mutable = 0;`,
         options: [true, { ignorePattern: "^mutable$" }]
       },
       {

--- a/tests/rules/immutable-data.test.ts
+++ b/tests/rules/immutable-data.test.ts
@@ -37,6 +37,18 @@ const objectES3Valid: ReadonlyArray<ValidTestCase> = [
       var b = Object.assign(bar(1, 2, 3), { d: 4 });
       var c = Object.assign(x.func(), { d: 4 });`,
     optionsSet: [[]]
+  },
+  // IgnoreAccessorPattern - objects.
+  {
+    code: dedent`
+      var mutableVar = { a: 1 };
+      mutableVar.a = 0;`,
+    optionsSet: [
+      [{ ignoreAccessorPattern: ["**.mutable*.a"] }],
+      [{ ignoreAccessorPattern: ["**.mutable*.*"] }],
+      [{ ignoreAccessorPattern: ["**.mutable*.*.**"] }],
+      [{ ignoreAccessorPattern: ["**.mutable*.**"] }]
+    ]
   }
 ];
 
@@ -267,6 +279,20 @@ const objectES6Valid: ReadonlyArray<ValidTestCase> = [
         }
       }`,
     optionsSet: [[]]
+  },
+  // IgnoreAccessorPattern - classes.
+  {
+    code: dedent`
+      class Klass {
+        mutate() {
+          this.mutableField = 0;
+        }
+      }`,
+    optionsSet: [
+      [{ ignoreAccessorPattern: ["this.*.**"] }],
+      [{ ignoreAccessorPattern: ["**.mutable*"] }],
+      [{ ignoreAccessorPattern: ["**.mutable*.**"] }]
+    ]
   }
 ];
 


### PR DESCRIPTION
Fixes #46

BREAKING CHANGE: `ignoreAccessorPattern` now matching the property name as well as the object name. Likewise with `ignorePattern`.