### PR TITLE
Do not enforce a parameter count by default in the lite ruleset

### DIFF
--- a/docs/rules/functional-parameters.md
+++ b/docs/rules/functional-parameters.md
@@ -37,6 +37,16 @@ const defaults = {
 };
 ```
 
+Note: the `lite` ruleset overrides the default options for this rule to:
+
+```ts
+{
+  allowRestParameter: false,
+  allowArgumentsKeyword: false,
+  enforceParameterCount: false
+}
+```
+
 ### `allowRestParameter`
 
 If true, this option allows for the use of rest parameters.

--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -1,4 +1,6 @@
-const config = {
+import { Config } from "../util/misc";
+
+const config: Config = {
   rules: {
     "functional/functional-parameters": "error",
     "functional/immutable-data": "error",

--- a/src/configs/currying.ts
+++ b/src/configs/currying.ts
@@ -1,4 +1,6 @@
-const config = {
+import { Config } from "../util/misc";
+
+const config: Config = {
   rules: {
     "functional/functional-parameters": "error"
   }

--- a/src/configs/external-recommended.ts
+++ b/src/configs/external-recommended.ts
@@ -1,4 +1,6 @@
-const config = {
+import { Config } from "../util/misc";
+
+const config: Config = {
   rules: {
     "prefer-const": "error",
     "no-param-reassign": "error",

--- a/src/configs/functional-lite.ts
+++ b/src/configs/functional-lite.ts
@@ -6,7 +6,13 @@ const config = deepMerge(functional, {
   rules: {
     "functional/no-conditional-statement": "off",
     "functional/no-expression-statement": "off",
-    "functional/no-try-statement": "off"
+    "functional/no-try-statement": "off",
+    "functional/functional-parameters": [
+      "error",
+      {
+        enforceParameterCount: false
+      }
+    ]
   }
 });
 

--- a/src/configs/functional-lite.ts
+++ b/src/configs/functional-lite.ts
@@ -2,7 +2,9 @@ import deepMerge from "deepmerge";
 
 import functional from "./functional";
 
-const config = deepMerge(functional, {
+import { Config } from "../util/misc";
+
+const config: Config = deepMerge<Config>(functional, {
   rules: {
     "functional/no-conditional-statement": "off",
     "functional/no-expression-statement": "off",

--- a/src/configs/functional.ts
+++ b/src/configs/functional.ts
@@ -6,7 +6,9 @@ import noExceptions from "./no-exceptions";
 import noObjectOrientation from "./no-object-orientation";
 import noStatements from "./no-statements";
 
-const config = deepMerge([
+import { Config } from "../util/misc";
+
+const config: Config = deepMerge<Config>([
   currying,
   noMutations,
   noExceptions,

--- a/src/configs/no-exceptions.ts
+++ b/src/configs/no-exceptions.ts
@@ -1,4 +1,6 @@
-const config = {
+import { Config } from "../util/misc";
+
+const config: Config = {
   rules: {
     "functional/no-throw-statement": "error",
     "functional/no-try-statement": "error"

--- a/src/configs/no-mutations.ts
+++ b/src/configs/no-mutations.ts
@@ -1,4 +1,6 @@
-const config = {
+import { Config } from "../util/misc";
+
+const config: Config = {
   rules: {
     "functional/no-let": "error",
     "functional/immutable-data": "error"

--- a/src/configs/no-object-orientation.ts
+++ b/src/configs/no-object-orientation.ts
@@ -1,4 +1,6 @@
-const config = {
+import { Config } from "../util/misc";
+
+const config: Config = {
   rules: {
     "functional/no-this-expression": "error",
     "functional/no-class": "error"

--- a/src/configs/no-statements.ts
+++ b/src/configs/no-statements.ts
@@ -1,4 +1,6 @@
-const config = {
+import { Config } from "../util/misc";
+
+const config: Config = {
   rules: {
     "functional/no-expression-statement": "error",
     "functional/no-conditional-statement": "error",

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -2,6 +2,7 @@ import {
   AST_NODE_TYPES,
   TSESTree
 } from "@typescript-eslint/experimental-utils";
+import { Linter } from "eslint";
 
 /**
  * Returns a function that checks if the given value is the same as the expected
@@ -23,3 +24,13 @@ export function isDirectivePrologue(
     node.expression.value.startsWith("use ")
   );
 }
+
+/**
+ * Eslint Config.
+ */
+export type Config = Linter.Config & {
+  readonly overrides?: ReadonlyArray<{
+    readonly files: ReadonlyArray<string>;
+    readonly rules: Linter.Config["rules"];
+  }>;
+};

--- a/tests/configs.test.ts
+++ b/tests/configs.test.ts
@@ -11,8 +11,7 @@ import noExceptions from "../src/configs/no-exceptions";
 import noObjectOrientation from "../src/configs/no-object-orientation";
 import noStatements from "../src/configs/no-statements";
 import { rules } from "../src/rules";
-
-import { Config } from "./helpers/util";
+import { Config } from "../src/util/misc";
 
 /**
  * Test the given config.
@@ -50,17 +49,11 @@ describe("configs", () => {
     });
   });
 
-  describe("Currying", testConfig(currying as Config, all as Config));
-  describe("Functional", testConfig(functional as Config, all as Config));
-  describe(
-    "Functional Lite",
-    testConfig(functionalLite as Config, all as Config)
-  );
-  describe("No Mutations", testConfig(noMutations as Config, all as Config));
-  describe("No Exceptions", testConfig(noExceptions as Config, all as Config));
-  describe(
-    "No Object Orientation",
-    testConfig(noObjectOrientation as Config, all as Config)
-  );
-  describe("No Statements", testConfig(noStatements as Config, all as Config));
+  describe("Currying", testConfig(currying, all));
+  describe("Functional", testConfig(functional, all));
+  describe("Functional Lite", testConfig(functionalLite, all));
+  describe("No Mutations", testConfig(noMutations, all));
+  describe("No Exceptions", testConfig(noExceptions, all));
+  describe("No Object Orientation", testConfig(noObjectOrientation, all));
+  describe("No Statements", testConfig(noStatements, all));
 });

--- a/tests/helpers/util.ts
+++ b/tests/helpers/util.ts
@@ -1,5 +1,5 @@
 import { TSESLint } from "@typescript-eslint/experimental-utils";
-import { Linter, Rule, RuleTester as ESLintRuleTester } from "eslint";
+import { Rule, RuleTester as ESLintRuleTester } from "eslint";
 import { filename } from "./configs";
 
 type OptionsSet = {
@@ -90,13 +90,6 @@ export function createDummyRule(
     create
   } as Rule.RuleModule;
 }
-
-export type Config = Linter.Config & {
-  readonly overrides?: ReadonlyArray<{
-    readonly files: ReadonlyArray<string>;
-    readonly rules: Linter.Config["rules"];
-  }>;
-};
 
 export type RuleTesterTests = {
   // eslint-disable-next-line functional/prefer-readonly-type


### PR DESCRIPTION
BREAKING CHANGE: The lite ruleset now behaves differently

fix #79