### PR TITLE
Add ignoreMutableCollections option to prefer-readonly-type rule

### DIFF
--- a/docs/rules/prefer-readonly-type.md
+++ b/docs/rules/prefer-readonly-type.md
@@ -96,7 +96,7 @@ This rule accepts an options object of the following type:
   checkImplicit: boolean;
   ignoreClass: boolean;
   ignoreInterface: boolean;
-  ignoreMutableCollections: boolean;
+  ignoreCollections: boolean;
   ignorePattern?: string | Array<string>;
 }
 ```
@@ -110,7 +110,7 @@ The default options:
   checkImplicit: false,
   ignoreClass: false,
   ignoreInterface: false,
-  ignoreMutableCollections: false,
+  ignoreCollections: false,
 }
 ```
 
@@ -172,14 +172,14 @@ interface {
 }
 ```
 
-### `ignoreMutableCollections`
+### `ignoreCollections`
 
 A boolean to specify if checking for `readonly` should apply to mutable collections (Array, Tuple, Set, and Map). Helpful for migrating from tslint-immutable to this plugin. `false` by default.
 
-Examples of **incorrect** code for the `{ "ignoreMutableCollections": false }` option:
+Examples of **incorrect** code for the `{ "ignoreCollections": false }` option:
 
 ```ts
-/* eslint functional/readonly: ["error", { "ignoreMutableCollections": false }] */
+/* eslint functional/readonly: ["error", { "ignoreCollections": false }] */
 
 const foo: number[] = [];
 const bar: [string, string] = ["foo", "bar"];
@@ -187,10 +187,10 @@ const baz: Set<string, string> = new Set();
 const qux: Map<string, string> = new Map();
 ```
 
-Examples of **correct** code for the `{ "ignoreMutableCollections": true }` option:
+Examples of **correct** code for the `{ "ignoreCollections": true }` option:
 
 ```ts
-/* eslint functional/readonly: ["error", { "ignoreMutableCollections": true }] */
+/* eslint functional/readonly: ["error", { "ignoreCollections": true }] */
 
 const foo: number[] = [];
 const bar: [string, string] = ["foo", "bar"];

--- a/docs/rules/prefer-readonly-type.md
+++ b/docs/rules/prefer-readonly-type.md
@@ -96,6 +96,7 @@ This rule accepts an options object of the following type:
   checkImplicit: boolean;
   ignoreClass: boolean;
   ignoreInterface: boolean;
+  ignoreMutableCollections: boolean;
   ignorePattern?: string | Array<string>;
 }
 ```
@@ -108,7 +109,8 @@ The default options:
   allowMutableReturnType: false,
   checkImplicit: false,
   ignoreClass: false,
-  ignoreInterface: false
+  ignoreInterface: false,
+  ignoreMutableCollections: false,
 }
 ```
 
@@ -168,6 +170,32 @@ Examples of **correct** code for the `{ "ignoreInterface": true }` option:
 interface {
   myprop: string;
 }
+```
+
+### `ignoreMutableCollections`
+
+A boolean to specify if checking for `readonly` should apply to mutable collections (Array, Tuple, Set, and Map). Helpful for migrating from tslint-immutable to this plugin. `false` by default.
+
+Examples of **incorrect** code for the `{ "ignoreMutableCollections": false }` option:
+
+```ts
+/* eslint functional/readonly: ["error", { "ignoreMutableCollections": false }] */
+
+const foo: number[] = [];
+const bar: [string, string] = ["foo", "bar"];
+const baz: Set<string, string> = new Set();
+const qux: Map<string, string> = new Map();
+```
+
+Examples of **correct** code for the `{ "ignoreMutableCollections": true }` option:
+
+```ts
+/* eslint functional/readonly: ["error", { "ignoreMutableCollections": true }] */
+
+const foo: number[] = [];
+const bar: [string, string] = ["foo", "bar"];
+const baz: Set<string, string> = new Set();
+const qux: Map<string, string> = new Map();
 ```
 
 ### `allowLocalMutation`

--- a/src/rules/prefer-readonly-type.ts
+++ b/src/rules/prefer-readonly-type.ts
@@ -114,7 +114,7 @@ const mutableToImmutableTypes: ReadonlyMap<string, string> = new Map<
   ["Set", "ReadonlySet"],
 ]);
 const mutableTypeRegex = new RegExp(
-  Array.from(mutableToImmutableTypes.keys()).join("|")
+  `^${Array.from(mutableToImmutableTypes.keys()).join("|")}$`
 );
 
 /**

--- a/src/rules/prefer-readonly-type.ts
+++ b/src/rules/prefer-readonly-type.ts
@@ -45,7 +45,7 @@ type Options = AllowLocalMutationOption &
   IgnoreInterfaceOption & {
     readonly allowMutableReturnType: boolean;
     readonly checkImplicit: boolean;
-    readonly ignoreMutableCollections: boolean;
+    readonly ignoreCollections: boolean;
   };
 
 // The schema for the rule options.
@@ -64,7 +64,7 @@ const schema: JSONSchema4 = [
         checkImplicit: {
           type: "boolean",
         },
-        ignoreMutableCollections: {
+        ignoreCollections: {
           type: "boolean",
         },
       },
@@ -78,7 +78,7 @@ const defaultOptions: Options = {
   checkImplicit: false,
   ignoreClass: false,
   ignoreInterface: false,
-  ignoreMutableCollections: false,
+  ignoreCollections: false,
   allowLocalMutation: false,
   allowMutableReturnType: false,
 };
@@ -125,7 +125,7 @@ function checkArrayOrTupleType(
   context: RuleContext<keyof typeof errorMessages, Options>,
   options: Options
 ): RuleResult<keyof typeof errorMessages, Options> {
-  if (options.ignoreMutableCollections) {
+  if (options.ignoreCollections) {
     return {
       context,
       descriptors: [],
@@ -191,7 +191,7 @@ function checkTypeReference(
 ): RuleResult<keyof typeof errorMessages, Options> {
   if (isIdentifier(node.typeName)) {
     if (
-      options.ignoreMutableCollections &&
+      options.ignoreCollections &&
       node.typeName.name.match(mutableTypeRegex)
     ) {
       return {
@@ -300,7 +300,7 @@ function checkImplicitType(
         declarator.id.typeAnnotation === undefined &&
         declarator.init !== null &&
         isArrayType(getTypeOfNode(declarator.init, context)) &&
-        !options.ignoreMutableCollections
+        !options.ignoreCollections
           ? [
               {
                 node: declarator.node,

--- a/tests/rules/prefer-readonly-type.test.ts
+++ b/tests/rules/prefer-readonly-type.test.ts
@@ -353,6 +353,47 @@ const valid: ReadonlyArray<ValidTestCase> = [
       } = {};`,
     optionsSet: [[{ ignorePattern: "^mutable" }]],
   },
+  // Ignore Mutable Collections (Array, Tuple, Set, Map)
+  {
+    code: dedent`type Foo = Array<string>;`,
+    optionsSet: [[{ ignoreMutableCollections: true }]],
+  },
+  {
+    code: dedent`const Foo: number[] = [];`,
+    optionsSet: [[{ ignoreMutableCollections: true }]],
+  },
+  {
+    code: dedent`const Foo = []`,
+    optionsSet: [[{ ignoreMutableCollections: true, checkImplicit: true }]],
+  },
+  {
+    code: dedent`type Foo = [string, string];`,
+    optionsSet: [[{ ignoreMutableCollections: true }]],
+  },
+  {
+    code: dedent`const Foo: [string, string] = ['foo', 'bar'];`,
+    optionsSet: [[{ ignoreMutableCollections: true }]],
+  },
+  {
+    code: dedent`const Foo = ['foo', 'bar'];`,
+    optionsSet: [[{ ignoreMutableCollections: true, checkImplicit: true }]],
+  },
+  {
+    code: dedent`type Foo = Set<string, string>;`,
+    optionsSet: [[{ ignoreMutableCollections: true }]],
+  },
+  {
+    code: dedent`const Foo: Set<string, string> = new Set();`,
+    optionsSet: [[{ ignoreMutableCollections: true }]],
+  },
+  {
+    code: dedent`type Foo = Map<string, string>;`,
+    optionsSet: [[{ ignoreMutableCollections: true }]],
+  },
+  {
+    code: dedent`const Foo: Map<string, string> = new Map();`,
+    optionsSet: [[{ ignoreMutableCollections: true }]],
+  },
 ];
 
 // Invalid test cases.

--- a/tests/rules/prefer-readonly-type.test.ts
+++ b/tests/rules/prefer-readonly-type.test.ts
@@ -356,43 +356,43 @@ const valid: ReadonlyArray<ValidTestCase> = [
   // Ignore Mutable Collections (Array, Tuple, Set, Map)
   {
     code: dedent`type Foo = Array<string>;`,
-    optionsSet: [[{ ignoreMutableCollections: true }]],
+    optionsSet: [[{ ignoreCollections: true }]],
   },
   {
     code: dedent`const Foo: number[] = [];`,
-    optionsSet: [[{ ignoreMutableCollections: true }]],
+    optionsSet: [[{ ignoreCollections: true }]],
   },
   {
     code: dedent`const Foo = []`,
-    optionsSet: [[{ ignoreMutableCollections: true, checkImplicit: true }]],
+    optionsSet: [[{ ignoreCollections: true, checkImplicit: true }]],
   },
   {
     code: dedent`type Foo = [string, string];`,
-    optionsSet: [[{ ignoreMutableCollections: true }]],
+    optionsSet: [[{ ignoreCollections: true }]],
   },
   {
     code: dedent`const Foo: [string, string] = ['foo', 'bar'];`,
-    optionsSet: [[{ ignoreMutableCollections: true }]],
+    optionsSet: [[{ ignoreCollections: true }]],
   },
   {
     code: dedent`const Foo = ['foo', 'bar'];`,
-    optionsSet: [[{ ignoreMutableCollections: true, checkImplicit: true }]],
+    optionsSet: [[{ ignoreCollections: true, checkImplicit: true }]],
   },
   {
     code: dedent`type Foo = Set<string, string>;`,
-    optionsSet: [[{ ignoreMutableCollections: true }]],
+    optionsSet: [[{ ignoreCollections: true }]],
   },
   {
     code: dedent`const Foo: Set<string, string> = new Set();`,
-    optionsSet: [[{ ignoreMutableCollections: true }]],
+    optionsSet: [[{ ignoreCollections: true }]],
   },
   {
     code: dedent`type Foo = Map<string, string>;`,
-    optionsSet: [[{ ignoreMutableCollections: true }]],
+    optionsSet: [[{ ignoreCollections: true }]],
   },
   {
     code: dedent`const Foo: Map<string, string> = new Map();`,
-    optionsSet: [[{ ignoreMutableCollections: true }]],
+    optionsSet: [[{ ignoreCollections: true }]],
   },
 ];
 


### PR DESCRIPTION
Hello! I'm currently migrating the main frontend repo for my company from a tslint / eslint hybrid to pure eslint. In our old config, we were using tslint-immutable's `readonly-keyword` to enforce use of `readonly` for our interfaces. However, we never enabled the `readonly-array` rule. Now that we're migrating to eslint-plugin-functional, we're getting a huge number of linting errors from the `prefer-readonly-type` rule since it appears to be a union of these two rules from tslint-immutable. While some of these are auto-fixable, many are not and fixing them manually would be too large of an undertaking for us right now.

To remedy this, I propose adding an `ignoreMutableCollections` option to this rule that allows users to disable checks against Arrays, Tuples, Maps, and Sets. This will make it much easier for users like us to migrate off of tslint and onto a more actively supported linting architecture. Happy to clarify the use case / expand on this PR as needed!