### PR TITLE
fix(prefer-type-literal): deprecated rule

### DIFF
--- a/src/rules/prefer-type-literal.ts
+++ b/src/rules/prefer-type-literal.ts
@@ -32,6 +32,8 @@ const errorMessages = {
 
 // The meta data for this rule.
 const meta: RuleMetaData<keyof typeof errorMessages> = {
+  deprecated: true,
+  replacedBy: ["@typescript-eslint/consistent-type-definitions"],
   type: "suggestion",
   docs: {
     description: "Prefer Type Literals over Interfaces.",


### PR DESCRIPTION
replaced by @typescript-eslint/consistent-type-definitions

fix #170