### PR TITLE
docs: fix typos and capitalization of words

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ An [ESLint](http://eslint.org) plugin to disable mutation and promote functional
 
 </div>
 
-> :wave: If you previously used the rules in [tslint-immutable](https://www.npmjs.com/package/tslint-immutable), this package is the eslint version of those rules. Please see the [migration guide](docs/user-guide/migrating-from-tslint.md) for how to migrate.
+> :wave: If you previously used the rules in [tslint-immutable](https://www.npmjs.com/package/tslint-immutable), this package is the ESLint version of those rules. Please see the [migration guide](docs/user-guide/migrating-from-tslint.md) for how to migrate.
 
 ## Features
 
@@ -36,7 +36,7 @@ JavaScript is multi-paradigm, allowing both object-oriented and functional progr
 
 ### No statements
 
-In functional programming everything is an expression that produces a value. Javascript has a lot of syntax that is just statements that does not produce a value. That syntax has to be disabled to promote a functional style.
+In functional programming everything is an expression that produces a value. JavaScript has a lot of syntax that is just statements that does not produce a value. That syntax has to be disabled to promote a functional style.
 
 ### No exceptions
 
@@ -44,7 +44,7 @@ Functional programming style does not use run-time exceptions. Instead expressio
 
 ### Currying
 
-Javascript functions support syntax that is not compatible with curried functions. To enable currying this syntax has to be disabled.
+JavaScript functions support syntax that is not compatible with curried functions. To enable currying this syntax has to be disabled.
 
 ### Stylitic
 
@@ -66,7 +66,7 @@ yarn add -D eslint eslint-plugin-functional
 
 ### TypeScript
 
-To use this plugin with TypeScript, a TypeScript parser for eslint is needed.
+To use this plugin with TypeScript, a TypeScript parser for ESLint is needed.
 We recommend [@typescript-eslint/parser](https://www.npmjs.com/package/@typescript-eslint/parser).
 
 ```sh
@@ -282,9 +282,9 @@ For new features file an issue. For bugs, file an issue and optionally file a PR
 
 To execute the tests run `yarn test`.
 
-To learn about eslint plugin development see the [relevant section](https://eslint.org/docs/developer-guide/working-with-plugins) of the eslint docs. You can also checkout the [typescript-eslint](https://github.com/typescript-eslint/typescript-eslint) repo which has some more information specific to typescript.
+To learn about ESLint plugin development see the [relevant section](https://eslint.org/docs/developer-guide/working-with-plugins) of the ESLint docs. You can also checkout the [typescript-eslint](https://github.com/typescript-eslint/typescript-eslint) repo which has some more information specific to TypeScript.
 
-In order to know which AST nodes are created for a snippet of TypeScript code you can use [ast explorer](https://astexplorer.net/) with options JavaScript and @typescript-eslint/parser.
+In order to know which AST nodes are created for a snippet of TypeScript code you can use [AST explorer](https://astexplorer.net/) with options JavaScript and @typescript-eslint/parser.
 
 ## How to publish
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Enable rulesets via the "extends" property of your `.eslintrc` configuration fil
 
 ### With TypeScript
 
-Add `@typescript-eslint/parser` to the "parser" filed in your `.eslintrc` configuration file.  
+Add `@typescript-eslint/parser` to the "parser" filed in your `.eslintrc` configuration file.
 To use type information, you will need to specify a path to your `tsconfig.json` file in the "project" property of "parserOptions".
 
 ```jsonc
@@ -182,7 +182,7 @@ The [below section](#supported-rules) gives details on which rules are enabled b
 |  :hear_no_evil:   | Ruleset: Lite<br><sub><sup>This ruleset is designed to enforce a somewhat functional programming code style.</sup></sub>               |
 |  :speak_no_evil:  | Ruleset: Recommended<br><sub><sup>This ruleset is designed to enforce a functional programming code style.</sup></sub>                 |
 |     :wrench:      | Fixable<br><sub><sup>Problems found by this rule are potentially fixable with the `--fix` option.</sup></sub>                          |
-| :thought_balloon: | Only Avaliable for TypeScript<br><sub><sup>The rule either requires Type Information or only works with TypeScript syntax.</sup></sub> |
+| :thought_balloon: | Only Available for TypeScript<br><sub><sup>The rule either requires Type Information or only works with TypeScript syntax.</sup></sub> |
 |   :blue_heart:    | Works better with TypeScript<br><sub><sup>Type Information will be used if available making the rule work in more cases.</sup></sub>   |
 
 ### No Mutations Rules

--- a/docs/rules/functional-parameters.md
+++ b/docs/rules/functional-parameters.md
@@ -1,4 +1,4 @@
-# Enforce Functional Parameters (functional-parameters)
+# Enforce functional parameters (functional-parameters)
 
 Disallow use of rest parameters, the `arguments` keyword and enforces that functions take a least 1 parameter.
 

--- a/docs/rules/functional-parameters.md
+++ b/docs/rules/functional-parameters.md
@@ -120,7 +120,7 @@ function add(x) {
 }
 ```
 
-See [Currying](https://en.wikipedia.org/wiki/Currying) and [Higher-order function](https://en.wikipedia.org/wiki/Higher-order_function) on Wikipedia for more infomation.
+See [Currying](https://en.wikipedia.org/wiki/Currying) and [Higher-order function](https://en.wikipedia.org/wiki/Higher-order_function) on Wikipedia for more information.
 
 #### `enforceParameterCount.count`
 
@@ -133,4 +133,4 @@ If true, this option allows for the use of [IIFEs](https://developer.mozilla.org
 ### `ignorePattern`
 
 Patterns will be matched against function names.
-See the [ignorePattern](./options/ignore-pattern.md) docs for more infomation.
+See the [ignorePattern](./options/ignore-pattern.md) docs for more information.

--- a/docs/rules/immutable-data.md
+++ b/docs/rules/immutable-data.md
@@ -107,13 +107,13 @@ const sorted = [...original].sort((a, b) => a.localeCompare(b)); // This is OK w
 ### `ignorePattern`
 
 Patterns will be matched against variable names.
-See the [ignorePattern](./options/ignore-pattern.md) docs for more infomation.
+See the [ignorePattern](./options/ignore-pattern.md) docs for more information.
 
 ### `ignoreAccessorPattern`
 
 This option takes a match string or an array of match strings (not a RegExp pattern).
 
-The match string allows you to specify dot seperated `.` object paths and has support for "glob" `*` and "globstar" `**` matching.
+The match string allows you to specify dot separated `.` object paths and has support for "glob" `*` and "globstar" `**` matching.
 
 For example:
 
@@ -148,7 +148,7 @@ For example:
 
 #### Wildcards
 
-The following wildcards can be used when specifing a pattern:
+The following wildcards can be used when specifying a pattern:
 
 `**` - Match any depth (including zero). Can only be used as a full accessor.
 `*` - When used as a full accessor, match the next accessor (there must be one). When used as part of an accessor, match any characters.

--- a/docs/rules/immutable-data.md
+++ b/docs/rules/immutable-data.md
@@ -78,7 +78,7 @@ The default options:
 The rule take advantage of TypeScript's typing engine to check if mutation is taking place.
 If you are not using TypeScript, type checking cannot be performed; hence this option exists.
 
-This option will make the rule assume the type of the nodes it is checking are of type Array/Object.  
+This option will make the rule assume the type of the nodes it is checking are of type Array/Object.
 However this may result in some false positives being picked up.
 
 Disabling this option can result in false negatives, for example:
@@ -90,7 +90,7 @@ x.push(3); // This will NOT be flagged.
 // This is due to the fact that without a typing engine, we cannot tell that x is an array.
 ```
 
-Note: This option will have no effect if the TypeScript typing engine is avaliable (i.e. you are using TypeScript and have configured eslint correctly).
+Note: This option will have no effect if the TypeScript typing engine is available (i.e. you are using TypeScript and have configured eslint correctly).
 
 ### `ignoreImmediateMutation`
 

--- a/docs/rules/immutable-data.md
+++ b/docs/rules/immutable-data.md
@@ -90,7 +90,7 @@ x.push(3); // This will NOT be flagged.
 // This is due to the fact that without a typing engine, we cannot tell that x is an array.
 ```
 
-Note: This option will have no effect if the TypeScript typing engine is available (i.e. you are using TypeScript and have configured eslint correctly).
+Note: This option will have no effect if the TypeScript typing engine is available (i.e. you are using TypeScript and have configured ESLint correctly).
 
 ### `ignoreImmediateMutation`
 

--- a/docs/rules/no-expression-statement.md
+++ b/docs/rules/no-expression-statement.md
@@ -54,4 +54,4 @@ The default options:
 ### `ignorePattern`
 
 Patterns will be matched against the line(s) of code.
-See the [ignorePattern](./options/ignore-pattern.md) docs for more infomation.
+See the [ignorePattern](./options/ignore-pattern.md) docs for more information.

--- a/docs/rules/no-let.md
+++ b/docs/rules/no-let.md
@@ -1,6 +1,6 @@
 # Disallow mutable variables (no-let)
 
-This rule should be combined with TSLint's built-in `no-var-keyword` rule to enforce that all variables are declared as `const`.
+This rule should be combined with ESLint's built-in `no-var` rule to enforce that all variables are declared as `const`.
 
 ## Rule Details
 

--- a/docs/rules/no-let.md
+++ b/docs/rules/no-let.md
@@ -1,6 +1,6 @@
 # Disallow mutable variables (no-let)
 
-This rule should be combined with tslint's built-in `no-var-keyword` rule to enforce that all variables are declared as `const`.
+This rule should be combined with TSLint's built-in `no-var-keyword` rule to enforce that all variables are declared as `const`.
 
 ## Rule Details
 

--- a/docs/rules/no-loop-statement.md
+++ b/docs/rules/no-loop-statement.md
@@ -4,7 +4,7 @@ This rule disallows for loop statements, including `for`, `for...of`, `for...in`
 
 ## Rule Details
 
-In functional programming we want everthing to be an expression that returns a value.
+In functional programming we want everything to be an expression that returns a value.
 Loops in JavaScript are statements so they are not a good fit for a functional programming style.
 Instead consider using `map`, `reduce` or similar.
 For more background see this [blog post](https://hackernoon.com/rethinking-javascript-death-of-the-for-loop-c431564c84a8) and discussion in [tslint-immutable #54](https://github.com/jonaskello/tslint-immutable/issues/54).

--- a/docs/rules/no-promise-reject.md
+++ b/docs/rules/no-promise-reject.md
@@ -1,4 +1,4 @@
-# Disallow Rejecting Promises (no-promise-reject)
+# Disallow rejecting Promises (no-promise-reject)
 
 This rule disallows use of `Promise.reject()`.
 

--- a/docs/rules/no-return-void.md
+++ b/docs/rules/no-return-void.md
@@ -1,4 +1,4 @@
-# Disallow Returning Nothing (no-return-void)
+# Disallow returning nothing (no-return-void)
 
 Disallow functions that are declared as returning nothing.
 

--- a/docs/rules/options/allow-local-mutation.md
+++ b/docs/rules/options/allow-local-mutation.md
@@ -3,7 +3,7 @@
 > If a tree falls in the woods, does it make a sound?
 > If a pure function mutates some local data in order to produce an immutable return value, is that ok?
 
-The quote above is from the [clojure docs](https://clojure.org/reference/transients).
+The quote above is from the [Clojure docs](https://clojure.org/reference/transients).
 In general, it is more important to enforce immutability for state that is passed in and out of functions than for local state used for internal calculations within a function.
 For example in Redux, the state going in and out of reducers needs to be immutable while the reducer may be allowed to mutate local state in its calculations in order to achieve higher performance.
 This is what the `allowLocalMutation` option enables. With this option enabled immutability will be enforced everywhere but in local state.

--- a/docs/rules/options/ignore-pattern.md
+++ b/docs/rules/options/ignore-pattern.md
@@ -12,9 +12,9 @@ type person = {
 };
 ```
 
-Typescript is not immutable by default but it can be if you use this package.
+TypeScript is not immutable by default but it can be if you use this package.
 So in order to create an escape hatch similar to how it is done in reason the `ignorePattern` option can be used.
-For example if you configure it to allow variables with names that has the prefix "mutable" you can emulate the above example in typescript like this:
+For example if you configure it to allow variables with names that has the prefix "mutable" you can emulate the above example in TypeScript like this:
 
 ```ts
 type person = {

--- a/docs/rules/prefer-tacit.md
+++ b/docs/rules/prefer-tacit.md
@@ -58,7 +58,7 @@ The default options:
 
 The rule take advantage of TypeScript's typing engine to check if callback wrapper is in fact safe to remove.
 
-This option will make the rule assume that the function only accepts the arguments given to it in the wrapper.  
+This option will make the rule assume that the function only accepts the arguments given to it in the wrapper.
 However this may result in some false positives being picked up.
 
 ```js
@@ -66,7 +66,7 @@ const foo = x => f(x);    // If `f` only accepts one parameter then this is viol
 const bar = foo(1, 2, 3); // But if `f` accepts more than one parameter then it isn't.
 ```
 
-Note: Enabling this option is the only way to get this rule to report violations in an environment without TypeScript's typing engine avaliable (e.g. In Vanilla JS).
+Note: Enabling this option is the only way to get this rule to report violations in an environment without TypeScript's typing engine available (e.g. In Vanilla JS).
 
 ### `assumeTypes.allowFixer`
 

--- a/docs/user-guide/migrating-from-tslint.md
+++ b/docs/user-guide/migrating-from-tslint.md
@@ -1,14 +1,14 @@
 # Migrating from TSLint
 
-In 2019, [palantir plans to deprecate TSLint](https://github.com/palantir/tslint/issues/4534) and support the migration to ESLint.
+In 2019, [Palantir plans to deprecate TSLint](https://github.com/palantir/tslint/issues/4534) and support the migration to ESLint.
 This guide is intended to help those who are using tslint-immutable to migrate their settings and projects to use eslint-plugin-functional.
 
 ## Configuration File
 
-The eslint version of `tslint.json` (the configuration file) is `.eslintrc`.
-See [eslint's docs](https://eslint.org/docs/user-guide/configuring) for mor information on this file.
+The ESLint version of `tslint.json` (the configuration file) is `.eslintrc`.
+See [ESLint's docs](https://eslint.org/docs/user-guide/configuring) for mor information on this file.
 
-Out of the box, eslint does not understand TypeScript. To get eslint to understand it we need to change the default parser to one that understands it.
+Out of the box, ESLint does not understand TypeScript. To get ESLint to understand it we need to change the default parser to one that understands it.
 This is where [@typescript-eslint](https://github.com/typescript-eslint/typescript-eslint) comes in.
 In the config file, we can specify the parser to be used with the "parser" key. Any extra parser configuration can then be specified under the "parserOptions" key.
 In order for the parser to have access to type information, it needs access to your `tsconfig.json`; you'll need to specify this under "parserOptions" -> "project".

--- a/docs/user-guide/migrating-from-tslint.md
+++ b/docs/user-guide/migrating-from-tslint.md
@@ -6,7 +6,7 @@ This guide is intended to help those who are using tslint-immutable to migrate t
 ## Configuration File
 
 The ESLint version of `tslint.json` (the configuration file) is `.eslintrc`.
-See [ESLint's docs](https://eslint.org/docs/user-guide/configuring) for mor information on this file.
+See [ESLint's docs](https://eslint.org/docs/user-guide/configuring) for more information on this file.
 
 Out of the box, ESLint does not understand TypeScript. To get ESLint to understand it we need to change the default parser to one that understands it.
 This is where [@typescript-eslint](https://github.com/typescript-eslint/typescript-eslint) comes in.

--- a/src/util/conditional-imports/typescript.ts
+++ b/src/util/conditional-imports/typescript.ts
@@ -1,7 +1,7 @@
 // Note: This import will be stripped out by rollup.
 import ts from "typescript";
 
-// Conditionally loaded TypeScript but only if it is avaliable.
+// Conditionally loaded TypeScript but only if it is available.
 export default (() => {
   try {
     return require("typescript") as typeof ts;

--- a/src/util/typeguard.ts
+++ b/src/util/typeguard.ts
@@ -9,7 +9,7 @@ import {
 // TS import - only use this for types, will be stripped out by rollup.
 import { Type, UnionType } from "typescript";
 
-// TS import - conditionally imported only when typescript is avaliable.
+// TS import - conditionally imported only when typescript is available.
 import ts from "../util/conditional-imports/typescript";
 
 // Any JSDoc for these functions would be tedious.


### PR DESCRIPTION
Fixes: –

# Proposed Changes

Mostly touched Markdown files. Did not touch the changelog.

Not sure about the word "stylitic." Is it intentional or should it be "stylistic" (notice the second "s")? _Stylitic_ is an adjective form of [_stylite_, which means "a Christian ascetic living atop a pillar."](https://www.merriam-webster.com/dictionary/stylite) Anyway, changing this might be a breaking change because the `stylitic` ruleset would need to be renamed, so it would be better to do it in a separate PR.