### PR TITLE
chore: update minimum required node version to 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup NodeJs
         uses: actions/setup-node@v1
         with:
-          node-version: "14"
+          node-version: "16"
 
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
@@ -48,10 +48,9 @@ jobs:
         os:
           - "ubuntu-latest"
         node_version:
-          - "10"
           - "12"
           - "14"
-          - "15"
+          - "16"
         ts_version:
           - "next"
           - "latest"
@@ -61,7 +60,7 @@ jobs:
     continue-on-error: ${{ matrix.ts_version == 'next' }}
     env:
       # Use compiled tests on everything instances except this one.
-      USE_COMPILED_TEST: ${{ fromJSON('["false", "true"]')[matrix.ts_version != 'latest' || matrix.node_version != '14' || matrix.os != 'ubuntu-latest'] }}
+      USE_COMPILED_TEST: ${{ fromJSON('["false", "true"]')[matrix.ts_version != 'latest' || matrix.node_version != '16' || matrix.os != 'ubuntu-latest'] }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -60,10 +60,8 @@
   },
   "dependencies": {
     "@typescript-eslint/experimental-utils": "^4.9.1",
-    "array.prototype.flatmap": "^1.2.4",
     "deepmerge": "^4.2.2",
-    "escape-string-regexp": "^4.0.0",
-    "object.fromentries": "^2.0.3"
+    "escape-string-regexp": "^4.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.0.0",
@@ -115,6 +113,6 @@
     }
   },
   "engines": {
-    "node": ">=10.18.0"
+    "node": ">=12.4.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,11 +9,6 @@ import rollupPluginTypescript from "@rollup/plugin-typescript";
 import rollupPluginJSON from "@rollup/plugin-json";
 import rollupPluginAutoExternal from "rollup-plugin-auto-external";
 
-const polyfills = [
-  "array.prototype.flatmap/auto.js",
-  "object.fromentries/auto.js",
-];
-
 const common = {
   input: "src/index.ts",
 
@@ -23,11 +18,11 @@ const common = {
     sourcemap: false,
   },
 
-  external: polyfills,
+  external: [],
 
   treeshake: {
     annotations: true,
-    moduleSideEffects: polyfills,
+    moduleSideEffects: [],
     propertyReadSideEffects: false,
     unknownGlobalSideEffects: false,
   },

--- a/src/common/ignore-options.ts
+++ b/src/common/ignore-options.ts
@@ -1,6 +1,3 @@
-// Polyfill.
-import "array.prototype.flatmap/auto.js";
-
 import { TSESTree } from "@typescript-eslint/experimental-utils";
 import escapeRegExp from "escape-string-regexp";
 import { JSONSchema4 } from "json-schema";

--- a/src/rules/prefer-readonly-type.ts
+++ b/src/rules/prefer-readonly-type.ts
@@ -1,6 +1,3 @@
-// Polyfill.
-import "array.prototype.flatmap/auto.js";
-
 import { TSESTree } from "@typescript-eslint/experimental-utils";
 import { all as deepMerge } from "deepmerge";
 import { JSONSchema4 } from "json-schema";

--- a/src/util/rule.ts
+++ b/src/util/rule.ts
@@ -1,6 +1,3 @@
-// Polyfill.
-import "object.fromentries/auto.js";
-
 import {
   ESLintUtils,
   TSESLint,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1069,16 +1069,6 @@ array.prototype.flat@^1.2.3:
     define-properties "^1.1.3"
     es-abstract "^1.18.0-next.1"
 
-array.prototype.flatmap@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.2.4.tgz#94cfd47cc1556ec0747d97f7c7738c58122004c9"
-  integrity sha512-r9Z0zYoxqHz60vvQbWEdXIEtCwHF0yxaWfno9qzXeNHvfyl3BZqygmGzb84dsubyaXLH4husF+NFgMSdpZhk2Q==
-  dependencies:
-    call-bind "^1.0.0"
-    define-properties "^1.1.3"
-    es-abstract "^1.18.0-next.1"
-    function-bind "^1.1.1"
-
 asn1@~0.2.3:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
@@ -1834,7 +1824,7 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.18.0-next.1, es-abstract@^1.18.0-next.2:
+es-abstract@^1.18.0-next.1:
   version "1.18.0-next.2"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.0-next.2.tgz#088101a55f0541f595e7e057199e27ddc8f3a5c2"
   integrity sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==
@@ -4096,16 +4086,6 @@ object.assign@^4.1.2:
     define-properties "^1.1.3"
     has-symbols "^1.0.1"
     object-keys "^1.1.1"
-
-object.fromentries@^2.0.3:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.4.tgz#26e1ba5c4571c5c6f0890cef4473066456a120b8"
-  integrity sha512-EsFBshs5RUUpQEY1D4q/m59kMfz4YJvxuNCJcv/jWwOJr34EaVnG11ZrZa0UHB3wnzV1wx8m58T4hQL8IuNXlQ==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.1.3"
-    es-abstract "^1.18.0-next.2"
-    has "^1.0.3"
 
 object.omit@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
BREAKING CHANGE: Node 12.4.0 or new is now required
