### PR TITLE
docs: enable GitHub discussions and remove link to spectrum

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -6,6 +6,7 @@ repository:
   private: false
   has_issues: true
   has_projects: true
+  has_discussions : true
   has_wiki: false
   has_downloads: true
   default_branch: master

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 [![Coverage Status](https://codecov.io/gh/jonaskello/eslint-plugin-functional/branch/master/graph/badge.svg)](https://codecov.io/gh/jonaskello/eslint-plugin-functional)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat)](https://github.com/prettier/prettier)
 [![MIT license](https://img.shields.io/github/license/jonaskello/eslint-plugin-functional.svg?style=flat)](https://opensource.org/licenses/MIT)
-[![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/eslint-functional)
 
 An [ESLint](http://eslint.org) plugin to disable mutation and promote functional programming in JavaScript and TypeScript.
 


### PR DESCRIPTION
Spectrum seems to be pretty dead these days. I think we should just simply use GitHub discussions instead.

Not sure if the settings app has been updated to support "has_discussions" but if not it could just be enable manually.

@jonaskello I haven't enabled GitHub discussions on any other repo before so I'm not sure if there's any extra setup required. I'll leave this to you to merge :)