### PR TITLE
fix(prefer-readonly-type): allow inline mutable return types

### DIFF
--- a/src/rules/prefer-readonly-type.ts
+++ b/src/rules/prefer-readonly-type.ts
@@ -234,24 +234,28 @@ function checkProperty(
     | TSESTree.TSIndexSignature
     | TSESTree.TSParameterProperty
     | TSESTree.TSPropertySignature,
-  context: RuleContext<keyof typeof errorMessages, Options>
+  context: RuleContext<keyof typeof errorMessages, Options>,
+  options: Options
 ): RuleResult<keyof typeof errorMessages, Options> {
   return {
     context,
-    descriptors: node.readonly
-      ? []
-      : [
-          {
-            node,
-            messageId: "property",
-            fix:
-              isTSIndexSignature(node) || isTSPropertySignature(node)
-                ? (fixer) => fixer.insertTextBefore(node, "readonly ")
-                : isTSParameterProperty(node)
-                ? (fixer) => fixer.insertTextBefore(node.parameter, "readonly ")
-                : (fixer) => fixer.insertTextBefore(node.key, "readonly "),
-          },
-        ],
+    descriptors:
+      !node.readonly &&
+      (!options.allowMutableReturnType || !isInReturnType(node))
+        ? [
+            {
+              node,
+              messageId: "property",
+              fix:
+                isTSIndexSignature(node) || isTSPropertySignature(node)
+                  ? (fixer) => fixer.insertTextBefore(node, "readonly ")
+                  : isTSParameterProperty(node)
+                  ? (fixer) =>
+                      fixer.insertTextBefore(node.parameter, "readonly ")
+                  : (fixer) => fixer.insertTextBefore(node.key, "readonly "),
+            },
+          ]
+        : [],
   };
 }
 

--- a/tests/rules/prefer-readonly-type.test.ts
+++ b/tests/rules/prefer-readonly-type.test.ts
@@ -145,6 +145,14 @@ const valid: ReadonlyArray<ValidTestCase> = [
       function foo<T>(x: T): T extends Array<number> ? string : number[] {}`,
     optionsSet: [[{ allowMutableReturnType: true }]],
   },
+  // Allow inline mutable return type.
+  {
+    code: dedent`
+      function foo(bar: string): { baz: number } {
+        return 1 as any;
+      }`,
+    optionsSet: [[{ allowMutableReturnType: true }]],
+  },
   // Should not fail on implicit ReadonlyArray type in variable declaration.
   {
     code: dedent`


### PR DESCRIPTION
Fixes: #98