### PR TITLE
New rule: prefer-readonly-type-alias

### DIFF
--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -22,6 +22,7 @@ const config: Linter.Config = {
         "functional/no-method-signature": "error",
         "functional/no-mixed-type": "error",
         "functional/prefer-readonly-type": "error",
+        "functional/prefer-readonly-type-alias": "error",
         "functional/prefer-tacit": ["error", { assumeTypes: false }],
         "functional/no-return-void": "error",
       },

--- a/src/configs/no-mutations.ts
+++ b/src/configs/no-mutations.ts
@@ -11,6 +11,7 @@ const config: Linter.Config = {
       rules: {
         "functional/no-method-signature": "warn",
         "functional/prefer-readonly-type": "error",
+        "functional/prefer-readonly-type-alias": "error",
       },
     },
   ],

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -13,6 +13,7 @@ import * as noThisExpression from "./no-this-expression";
 import * as noThrowStatement from "./no-throw-statement";
 import * as noTryStatement from "./no-try-statement";
 import * as preferReadonlyTypes from "./prefer-readonly-type";
+import * as preferReadonlyTypeAlias from "./prefer-readonly-type-alias";
 import * as preferTacit from "./prefer-tacit";
 
 /**
@@ -34,5 +35,6 @@ export const rules = {
   [noThrowStatement.name]: noThrowStatement.rule,
   [noTryStatement.name]: noTryStatement.rule,
   [preferReadonlyTypes.name]: preferReadonlyTypes.rule,
+  [preferReadonlyTypeAlias.name]: preferReadonlyTypeAlias.rule,
   [preferTacit.name]: preferTacit.rule,
 };

--- a/src/rules/prefer-readonly-type-alias.ts
+++ b/src/rules/prefer-readonly-type-alias.ts
@@ -1,0 +1,248 @@
+import type { TSESTree } from "@typescript-eslint/experimental-utils";
+import type { JSONSchema4 } from "json-schema";
+
+import type { RuleContext, RuleMetaData, RuleResult } from "~/util/rule";
+import { createRule, isReadonly } from "~/util/rule";
+
+// The name of this rule.
+export const name = "prefer-readonly-type-alias" as const;
+
+const enum RequiredReadonlyness {
+  READONLY,
+  MUTABLE,
+  EITHER,
+}
+
+// The options this rule can take.
+type Options = {
+  readonly mustBeReadonly: {
+    readonly pattern: ReadonlyArray<string> | string;
+    readonly requireOthersToBeMutable: boolean;
+  };
+  readonly mustBeMutable: {
+    readonly pattern: ReadonlyArray<string> | string;
+    readonly requireOthersToBeReadonly: boolean;
+  };
+  readonly blacklist: ReadonlyArray<string>;
+};
+
+// The schema for the rule options.
+const schema: JSONSchema4 = [
+  {
+    type: "object",
+    properties: {
+      mustBeReadonly: {
+        type: "object",
+        properties: {
+          pattern: {
+            type: ["string", "array"],
+            items: {
+              type: "string",
+            },
+          },
+          requireOthersToBeMutable: {
+            type: "boolean",
+          },
+        },
+        additionalProperties: false,
+      },
+      mustBeMutable: {
+        type: "object",
+        properties: {
+          pattern: {
+            type: ["string", "array"],
+            items: {
+              type: "string",
+            },
+          },
+          requireOthersToBeReadonly: {
+            type: "boolean",
+          },
+        },
+        additionalProperties: false,
+      },
+      blacklist: {
+        type: "array",
+        items: {
+          type: "string",
+        },
+      },
+    },
+    additionalProperties: false,
+  },
+];
+
+// The default options for the rule.
+const defaultOptions: Options = {
+  mustBeReadonly: {
+    pattern: "^Readonly",
+    requireOthersToBeMutable: false,
+  },
+  mustBeMutable: {
+    pattern: "^Mutable",
+    requireOthersToBeReadonly: true,
+  },
+  blacklist: ["^Mutable$"],
+};
+
+// The possible error messages.
+const errorMessages = {
+  mutable: "Mutable types should not be fully readonly.",
+  readonly: "Readonly types should not be mutable at all.",
+  mutableReadonly:
+    "Configuration error - this type must be marked as both readonly and mutable.",
+  needsExplicitMarking:
+    "Type must be explicity marked as either readonly or mutable.",
+} as const;
+
+// The meta data for this rule.
+const meta: RuleMetaData<keyof typeof errorMessages> = {
+  type: "suggestion",
+  docs: {
+    description: "Prefer readonly type alias over mutable one.",
+    category: "Best Practices",
+    recommended: "error",
+  },
+  messages: errorMessages,
+  fixable: "code",
+  schema,
+};
+
+/**
+ * Check if the given TypeReference violates this rule.
+ */
+function checkTypeAliasDeclaration(
+  node: TSESTree.TSTypeAliasDeclaration,
+  context: RuleContext<keyof typeof errorMessages, Options>,
+  options: Options
+): RuleResult<keyof typeof errorMessages, Options> {
+  const blacklistPatterns = (
+    Array.isArray(options.blacklist) ? options.blacklist : [options.blacklist]
+  ).map((pattern) => new RegExp(pattern, "u"));
+
+  const blacklisted = blacklistPatterns.some((pattern) =>
+    pattern.test(node.id.name)
+  );
+
+  if (blacklisted) {
+    return {
+      context,
+      descriptors: [],
+    };
+  }
+
+  const mustBeReadonlyPatterns = (
+    Array.isArray(options.mustBeReadonly.pattern)
+      ? options.mustBeReadonly.pattern
+      : [options.mustBeReadonly.pattern]
+  ).map((pattern) => new RegExp(pattern, "u"));
+
+  const mustBeMutablePatterns = (
+    Array.isArray(options.mustBeMutable.pattern)
+      ? options.mustBeMutable.pattern
+      : [options.mustBeMutable.pattern]
+  ).map((pattern) => new RegExp(pattern, "u"));
+
+  const patternStatesReadonly = mustBeReadonlyPatterns.some((pattern) =>
+    pattern.test(node.id.name)
+  );
+  const patternStatesMutable = mustBeMutablePatterns.some((pattern) =>
+    pattern.test(node.id.name)
+  );
+
+  if (patternStatesReadonly && patternStatesMutable) {
+    return {
+      context,
+      descriptors: [
+        {
+          node: node.id,
+          messageId: "mutableReadonly",
+        },
+      ],
+    };
+  }
+
+  if (
+    !patternStatesReadonly &&
+    !patternStatesMutable &&
+    options.mustBeReadonly.requireOthersToBeMutable &&
+    options.mustBeMutable.requireOthersToBeReadonly
+  ) {
+    return {
+      context,
+      descriptors: [
+        {
+          node: node.id,
+          messageId: "needsExplicitMarking",
+        },
+      ],
+    };
+  }
+
+  const requiredReadonlyness =
+    patternStatesReadonly ||
+    (!patternStatesMutable && options.mustBeMutable.requireOthersToBeReadonly)
+      ? RequiredReadonlyness.READONLY
+      : patternStatesMutable ||
+        (!patternStatesReadonly &&
+          options.mustBeReadonly.requireOthersToBeMutable)
+      ? RequiredReadonlyness.MUTABLE
+      : RequiredReadonlyness.EITHER;
+
+  return checkRequiredReadonlyness(
+    node,
+    context,
+    options,
+    requiredReadonlyness
+  );
+}
+
+function checkRequiredReadonlyness(
+  node: TSESTree.TSTypeAliasDeclaration,
+  context: RuleContext<keyof typeof errorMessages, Options>,
+  options: Options,
+  requiredReadonlyness: RequiredReadonlyness
+): RuleResult<keyof typeof errorMessages, Options> {
+  if (requiredReadonlyness !== RequiredReadonlyness.EITHER) {
+    const readonly = isReadonly(node.typeAnnotation, context);
+
+    if (readonly && requiredReadonlyness === RequiredReadonlyness.MUTABLE) {
+      return {
+        context,
+        descriptors: [
+          {
+            node: node.id,
+            messageId: "readonly",
+          },
+        ],
+      };
+    }
+
+    if (!readonly && requiredReadonlyness === RequiredReadonlyness.READONLY) {
+      return {
+        context,
+        descriptors: [
+          {
+            node: node.id,
+            messageId: "mutable",
+          },
+        ],
+      };
+    }
+  }
+
+  return {
+    context,
+    descriptors: [],
+  };
+}
+
+// Create the rule.
+export const rule = createRule<keyof typeof errorMessages, Options>(
+  name,
+  meta,
+  defaultOptions,
+  {
+    TSTypeAliasDeclaration: checkTypeAliasDeclaration,
+  }
+);

--- a/src/util/rule.ts
+++ b/src/util/rule.ts
@@ -138,6 +138,21 @@ export function getTypeOfNode<Context extends RuleContext<string, BaseOptions>>(
   return constrained ?? nodeType;
 }
 
+export function isReadonly<Context extends RuleContext<string, BaseOptions>>(
+  node: TSESTree.Node,
+  context: Context
+): boolean {
+  const { parserServices } = context;
+
+  if (parserServices === undefined || parserServices.program === undefined) {
+    return false;
+  }
+
+  const checker = parserServices.program.getTypeChecker();
+  const type = getTypeOfNode(node, context);
+  return ESLintUtils.isTypeReadonly(checker, type!);
+}
+
 /**
  * Get the es tree node from the given ts node.
  */

--- a/src/util/tree.ts
+++ b/src/util/tree.ts
@@ -10,13 +10,12 @@ import {
   isMethodDefinition,
   isProperty,
   isTSInterfaceBody,
-  isTSTypeAliasDeclaration,
 } from "./typeguard";
 
 /**
  * Return the first ancestor that meets the given check criteria.
  */
-function getAncestorOfType<T extends TSESTree.Node>(
+export function getAncestorOfType<T extends TSESTree.Node>(
   checker: (node: TSESTree.Node, child: TSESTree.Node | null) => node is T,
   node: TSESTree.Node,
   child: TSESTree.Node | null = null
@@ -80,22 +79,6 @@ export function isInReturnType(node: TSESTree.Node): boolean {
       node
     ) !== null
   );
-}
-
-/**
- * Is the given node in a type alias.
- */
-export function getParentTypeAliasDeclaration(
-  node: TSESTree.Node
-): TSESTree.TSTypeAliasDeclaration | null {
-  return (getAncestorOfType(
-    (n): n is TSESTree.Node =>
-      n.parent !== undefined &&
-      n.parent !== null &&
-      isTSTypeAliasDeclaration(n.parent) &&
-      n.parent.typeAnnotation === n,
-    node
-  )?.parent ?? null) as TSESTree.TSTypeAliasDeclaration | null;
 }
 
 /**

--- a/src/util/tree.ts
+++ b/src/util/tree.ts
@@ -10,6 +10,7 @@ import {
   isMethodDefinition,
   isProperty,
   isTSInterfaceBody,
+  isTSTypeAliasDeclaration,
 } from "./typeguard";
 
 /**
@@ -79,6 +80,22 @@ export function isInReturnType(node: TSESTree.Node): boolean {
       node
     ) !== null
   );
+}
+
+/**
+ * Is the given node in a type alias.
+ */
+export function getParentTypeAliasDeclaration(
+  node: TSESTree.Node
+): TSESTree.TSTypeAliasDeclaration | null {
+  return (getAncestorOfType(
+    (n): n is TSESTree.Node =>
+      n.parent !== undefined &&
+      n.parent !== null &&
+      isTSTypeAliasDeclaration(n.parent) &&
+      n.parent.typeAnnotation === n,
+    node
+  )?.parent ?? null) as TSESTree.TSTypeAliasDeclaration | null;
 }
 
 /**

--- a/src/util/typeguard.ts
+++ b/src/util/typeguard.ts
@@ -210,6 +210,12 @@ export function isTSInterfaceBody(
   return node.type === AST_NODE_TYPES.TSInterfaceBody;
 }
 
+export function isTSTypeAliasDeclaration(
+  node: TSESTree.Node
+): node is TSESTree.TSTypeAliasDeclaration {
+  return node.type === AST_NODE_TYPES.TSTypeAliasDeclaration;
+}
+
 export function isTSNullKeyword(
   node: TSESTree.Node
 ): node is TSESTree.TSNullKeyword {

--- a/src/util/typeguard.ts
+++ b/src/util/typeguard.ts
@@ -204,6 +204,12 @@ export function isTSIndexSignature(
   return node.type === AST_NODE_TYPES.TSIndexSignature;
 }
 
+export function isTSInterfaceDeclaration(
+  node: TSESTree.Node
+): node is TSESTree.TSInterfaceDeclaration {
+  return node.type === AST_NODE_TYPES.TSInterfaceDeclaration;
+}
+
 export function isTSInterfaceBody(
   node: TSESTree.Node
 ): node is TSESTree.TSInterfaceBody {

--- a/tests/rules/prefer-readonly-type-alias/index.test.ts
+++ b/tests/rules/prefer-readonly-type-alias/index.test.ts
@@ -1,0 +1,6 @@
+import { name, rule } from "~/rules/prefer-readonly-type-alias";
+import { testUsing } from "~/tests/helpers/testers";
+
+import tsTests from "./ts";
+
+testUsing.typescript(name, rule, tsTests);

--- a/tests/rules/prefer-readonly-type-alias/ts/index.ts
+++ b/tests/rules/prefer-readonly-type-alias/ts/index.ts
@@ -1,0 +1,7 @@
+import invalid from "./invalid";
+import valid from "./valid";
+
+export default {
+  valid,
+  invalid,
+};

--- a/tests/rules/prefer-readonly-type-alias/ts/invalid.ts
+++ b/tests/rules/prefer-readonly-type-alias/ts/invalid.ts
@@ -137,7 +137,7 @@ const tests: ReadonlyArray<InvalidTestCase> = [
         readonly [key: string]: string
       }
       type MyType2 = {
-        readonly [key: string]: { readonly prop: string }
+        readonly [key: string]: { prop: string }
       }`,
     errors: [
       {
@@ -163,12 +163,6 @@ const tests: ReadonlyArray<InvalidTestCase> = [
         type: "TSIndexSignature",
         line: 5,
         column: 3,
-      },
-      {
-        messageId: "propertyShouldBeReadonly",
-        type: "TSPropertySignature",
-        line: 5,
-        column: 20,
       },
     ],
   },
@@ -385,6 +379,232 @@ const tests: ReadonlyArray<InvalidTestCase> = [
         type: "TSTypeReference",
         line: 1,
         column: 23,
+      },
+    ],
+  },
+  // Tuples.
+  {
+    code: dedent`
+      type MyType = [number, string];`,
+    optionsSet: [[]],
+    output: dedent`
+      type MyType = readonly [number, string];`,
+    errors: [
+      {
+        messageId: "typeAliasShouldBeReadonly",
+        type: "Identifier",
+        line: 1,
+        column: 6,
+      },
+      {
+        messageId: "tupleShouldBeReadonly",
+        type: "TSTupleType",
+        line: 1,
+        column: 15,
+      },
+    ],
+  },
+  // Should fail on Array type in interface.
+  {
+    code: dedent`
+      interface Foo {
+        readonly bar: Array<string>
+      }`,
+    optionsSet: [[]],
+    output: dedent`
+      interface Foo {
+        readonly bar: ReadonlyArray<string>
+      }`,
+    errors: [
+      {
+        messageId: "typeAliasShouldBeReadonly",
+        type: "Identifier",
+        line: 1,
+        column: 11,
+      },
+      {
+        messageId: "typeShouldBeReadonly",
+        type: "TSTypeReference",
+        line: 2,
+        column: 17,
+      },
+    ],
+  },
+  // Should fail on mutable index signature but not on index signature internals.
+  // https://github.com/typescript-eslint/typescript-eslint/issues/3714
+  {
+    code: dedent`
+      interface Foo {
+        [key: string]: {
+          readonly groups: Array<string>
+        }
+      }`,
+    optionsSet: [[]],
+    output: dedent`
+      interface Foo {
+        readonly [key: string]: {
+          readonly groups: Array<string>
+        }
+      }`,
+    errors: [
+      {
+        messageId: "typeAliasShouldBeReadonly",
+        type: "Identifier",
+        line: 1,
+        column: 11,
+      },
+      {
+        messageId: "propertyShouldBeReadonly",
+        type: "TSIndexSignature",
+        line: 2,
+        column: 3,
+      },
+    ],
+  },
+  // Interface Index Signatures.
+  {
+    code: dedent`
+      interface Foo {
+        [key: string]: string
+      }
+      interface Bar {
+        [key: string]: { prop: string }
+      }`,
+    optionsSet: [[]],
+    output: dedent`
+      interface Foo {
+        readonly [key: string]: string
+      }
+      interface Bar {
+        readonly [key: string]: { prop: string }
+      }`,
+    errors: [
+      {
+        messageId: "typeAliasShouldBeReadonly",
+        type: "Identifier",
+        line: 1,
+        column: 11,
+      },
+      {
+        messageId: "propertyShouldBeReadonly",
+        type: "TSIndexSignature",
+        line: 2,
+        column: 3,
+      },
+      {
+        messageId: "typeAliasShouldBeReadonly",
+        type: "Identifier",
+        line: 4,
+        column: 11,
+      },
+      {
+        messageId: "propertyShouldBeReadonly",
+        type: "TSIndexSignature",
+        line: 5,
+        column: 3,
+      },
+    ],
+  },
+  // Type literal without readonly on members should produce failures.
+  // Also verify that nested members are checked.
+  {
+    code: dedent`
+      type MyType = {
+        a: number,
+        b: ReadonlyArray<string>,
+        c: () => string,
+        d: { readonly [key: string]: string },
+        [key: string]: string,
+        readonly e: {
+          a: number,
+          b: ReadonlyArray<string>,
+          c: () => string,
+          d: { readonly [key: string]: string },
+          [key: string]: string,
+        }
+      };`,
+    optionsSet: [[]],
+    output: dedent`
+      type MyType = {
+        readonly a: number,
+        readonly b: ReadonlyArray<string>,
+        readonly c: () => string,
+        readonly d: { readonly [key: string]: string },
+        readonly [key: string]: string,
+        readonly e: {
+          readonly a: number,
+          readonly b: ReadonlyArray<string>,
+          readonly c: () => string,
+          readonly d: { readonly [key: string]: string },
+          readonly [key: string]: string,
+        }
+      };`,
+    errors: [
+      {
+        messageId: "typeAliasShouldBeReadonly",
+        type: "Identifier",
+        line: 1,
+        column: 6,
+      },
+      {
+        messageId: "propertyShouldBeReadonly",
+        type: "TSPropertySignature",
+        line: 2,
+        column: 3,
+      },
+      {
+        messageId: "propertyShouldBeReadonly",
+        type: "TSPropertySignature",
+        line: 3,
+        column: 3,
+      },
+      {
+        messageId: "propertyShouldBeReadonly",
+        type: "TSPropertySignature",
+        line: 4,
+        column: 3,
+      },
+      {
+        messageId: "propertyShouldBeReadonly",
+        type: "TSPropertySignature",
+        line: 5,
+        column: 3,
+      },
+      {
+        messageId: "propertyShouldBeReadonly",
+        type: "TSIndexSignature",
+        line: 6,
+        column: 3,
+      },
+      {
+        messageId: "propertyShouldBeReadonly",
+        type: "TSPropertySignature",
+        line: 8,
+        column: 5,
+      },
+      {
+        messageId: "propertyShouldBeReadonly",
+        type: "TSPropertySignature",
+        line: 9,
+        column: 5,
+      },
+      {
+        messageId: "propertyShouldBeReadonly",
+        type: "TSPropertySignature",
+        line: 10,
+        column: 5,
+      },
+      {
+        messageId: "propertyShouldBeReadonly",
+        type: "TSPropertySignature",
+        line: 11,
+        column: 5,
+      },
+      {
+        messageId: "propertyShouldBeReadonly",
+        type: "TSIndexSignature",
+        line: 12,
+        column: 5,
       },
     ],
   },

--- a/tests/rules/prefer-readonly-type-alias/ts/invalid.ts
+++ b/tests/rules/prefer-readonly-type-alias/ts/invalid.ts
@@ -1,0 +1,129 @@
+import dedent from "dedent";
+
+import type { InvalidTestCase } from "~/tests/helpers/util";
+
+const optionsReversedDefault = [
+  {
+    mustBeReadonly: {
+      requireOthersToBeMutable: true,
+    },
+    mustBeMutable: {
+      requireOthersToBeReadonly: false,
+    },
+  },
+];
+
+const tests: ReadonlyArray<InvalidTestCase> = [
+  // Readonly types should not be mutable.
+  {
+    code: dedent`
+      type MyType = {
+        a: string;
+      };`,
+    optionsSet: [[]],
+    // output: dedent`
+    //   type MyType = {
+    //     readonly a: string;
+    //   };`,
+    errors: [
+      {
+        messageId: "mutable",
+        type: "Identifier",
+        line: 1,
+        column: 6,
+      },
+    ],
+  },
+  // Mutable types should not be readonly.
+  {
+    code: dedent`
+      type MyType = {
+        readonly a: string;
+      };`,
+    optionsSet: [optionsReversedDefault],
+    // output: dedent`
+    //   type MyType = {
+    //     a: string;
+    //   };`,
+    errors: [
+      {
+        messageId: "readonly",
+        type: "Identifier",
+        line: 1,
+        column: 6,
+      },
+    ],
+  },
+  // Mutable types should not be readonly.
+  {
+    code: dedent`
+      type MutableMyType = {
+        readonly a: string;
+      };`,
+    optionsSet: [[]],
+    // output: dedent`
+    //   type MutableMyType = {
+    //     a: string;
+    //   };`,
+    errors: [
+      {
+        messageId: "readonly",
+        type: "Identifier",
+        line: 1,
+        column: 6,
+      },
+    ],
+  },
+  // Needs Explicit Marking.
+  {
+    code: dedent`
+      type MyType = {};`,
+    optionsSet: [
+      [
+        {
+          mustBeReadonly: {
+            requireOthersToBeMutable: true,
+          },
+          mustBeMutable: {
+            requireOthersToBeReadonly: true,
+          },
+        },
+      ],
+    ],
+    errors: [
+      {
+        messageId: "needsExplicitMarking",
+        type: "Identifier",
+        line: 1,
+        column: 6,
+      },
+    ],
+  },
+  // Both Mutable and Readonly error.
+  {
+    code: dedent`
+      type MyType = {};`,
+    optionsSet: [
+      [
+        {
+          mustBeReadonly: {
+            pattern: ".*",
+          },
+          mustBeMutable: {
+            pattern: ".*",
+          },
+        },
+      ],
+    ],
+    errors: [
+      {
+        messageId: "mutableReadonly",
+        type: "Identifier",
+        line: 1,
+        column: 6,
+      },
+    ],
+  },
+];
+
+export default tests;

--- a/tests/rules/prefer-readonly-type-alias/ts/valid.ts
+++ b/tests/rules/prefer-readonly-type-alias/ts/valid.ts
@@ -65,6 +65,88 @@ const tests: ReadonlyArray<ValidTestCase> = [
       type MyType = Mutable<ReadonlyMyType>;`,
     optionsSet: [optionsReversedDefault],
   },
+  // Readonly Tuple.
+  {
+    code: dedent`
+      type MyType = readonly [number, string, readonly [number, string]];`,
+    optionsSet: [[]],
+  },
+  // Should not fail on ReadonlyArray type alias.
+  {
+    code: `type Foo = ReadonlyArray<string>;`,
+    optionsSet: [[]],
+  },
+  // Interface with readonly modifiers should not produce failures.
+  {
+    code: dedent`
+      interface Foo {
+        readonly a: number,
+        readonly b: ReadonlyArray<string>,
+        readonly c: () => string,
+        readonly d: { readonly [key: string]: string },
+        readonly [key: string]: string,
+      }`,
+    optionsSet: [[]],
+  },
+  // PropertySignature and IndexSignature members without readonly modifier
+  // should produce failures. Also verify that nested members are checked.
+  {
+    code: dedent`
+      interface Foo {
+        readonly a: number,
+        readonly b: ReadonlyArray<string>,
+        readonly c: () => string,
+        readonly d: { readonly [key: string]: string },
+        readonly [key: string]: string,
+        readonly e: {
+          readonly a: number,
+          readonly b: ReadonlyArray<string>,
+          readonly c: () => string,
+          readonly d: { readonly [key: string]: string },
+          readonly [key: string]: string,
+        }
+      }`,
+    optionsSet: [[]],
+  },
+  // CallSignature and MethodSignature cannot have readonly modifiers and should
+  // not produce failures.
+  // Waiting on https://github.com/typescript-eslint/typescript-eslint/issues/1758
+  // {
+  //   code: dedent`
+  //     interface Foo {
+  //       (): void
+  //       foo(): void
+  //     }`,
+  //   optionsSet: [
+  //     [
+  //       {
+  //         treatMethodsAsReadonly: true,
+  //       },
+  //     ],
+  //   ],
+  // },
+  // Type literal in array template parameter with readonly should not produce failures.
+  {
+    code: `type foo = ReadonlyArray<{ readonly type: string, readonly code: string }>;`,
+    optionsSet: [[]],
+  },
+  // Mapped types with readonly on members should not produce failures.
+  {
+    code: dedent`
+      type MyType = (x: { readonly [key in string]: number }) => {}`,
+    optionsSet: [[]],
+  },
+  // Ignore Interfaces.
+  {
+    code: dedent`
+      interface Foo {
+        foo: number,
+        bar: ReadonlyArray<string>,
+        baz: () => string,
+        qux: { [key: string]: string }
+      }`,
+    optionsSet: [[{ ignoreInterface: true }]],
+  },
 ];
 
 export default tests;

--- a/tests/rules/prefer-readonly-type-alias/ts/valid.ts
+++ b/tests/rules/prefer-readonly-type-alias/ts/valid.ts
@@ -1,0 +1,70 @@
+import dedent from "dedent";
+
+import type { ValidTestCase } from "~/tests/helpers/util";
+
+const optionsReversedDefault = [
+  {
+    mustBeReadonly: {
+      requireOthersToBeMutable: true,
+    },
+    mustBeMutable: {
+      requireOthersToBeReadonly: false,
+    },
+  },
+];
+
+const tests: ReadonlyArray<ValidTestCase> = [
+  // Readonly types should be readonly.
+  {
+    code: dedent`
+      type MyType = {
+        readonly a: string;
+      };`,
+    optionsSet: [[]],
+  },
+  {
+    code: dedent`
+      type ReadonlyMyType = {
+        readonly a: string;
+      };`,
+    optionsSet: [optionsReversedDefault],
+  },
+  // Readonly types should be readonly and mutable types mutable.
+  {
+    code: dedent`
+      type MutableMyType = {
+        a: string;
+      };
+      type MyType = Readonly<MutableMyType>;`,
+    optionsSet: [[]],
+  },
+  {
+    code: dedent`
+      type MyType = {
+        a: string;
+      };
+      type ReadonlyMyType = Readonly<MyType>;`,
+    optionsSet: [optionsReversedDefault],
+  },
+  // Readonly types should be readonly and mutable types mutable.
+  {
+    code: dedent`
+      type Mutable<T> = { -readonly[P in keyof T]: T[P] };
+      type MyType = {
+        readonly a: string;
+      };
+      type MutableMyType = Mutable<MyType>;`,
+    optionsSet: [[]],
+  },
+  {
+    code: dedent`
+      type Mutable<T> = { -readonly[P in keyof T]: T[P] };
+      type ReadonlyMyType = {
+        readonly a: string;
+      };
+      type MyType = Mutable<ReadonlyMyType>;`,
+    optionsSet: [optionsReversedDefault],
+  },
+];
+
+export default tests;


### PR DESCRIPTION
Note: The rule might want a new name as it can also require aliases to be mutable.

By default, this rule requires that all type aliases are deeply readonly unless prefixed with `Mutable`.
I can however be configured to work the other way around and require that all type aliases are not deeply readonly unless prefixed with `Readonly`.

It's also possible to have a mixture of both these configure and to use other patterns to determine readonly vs mutable.