### PR TITLE
feat(no-method-signature): properly handle `Readonly<{TSMethodSignature}>`

### DIFF
--- a/src/rules/no-method-signature.ts
+++ b/src/rules/no-method-signature.ts
@@ -7,6 +7,7 @@ import {
   RuleMetaData,
   RuleResult,
 } from "../util/rule";
+import { inReadonly } from "../util/tree";
 
 // The name of this rule.
 export const name = "no-method-signature" as const;
@@ -46,6 +47,10 @@ function checkTSMethodSignature(
   node: TSESTree.TSMethodSignature,
   context: RuleContext<keyof typeof errorMessages, Options>
 ): RuleResult<keyof typeof errorMessages, Options> {
+  if (inReadonly(node)) {
+    return { context, descriptors: [] };
+  }
+
   // All TS method signatures violate this rule.
   return { context, descriptors: [{ node, messageId: "generic" }] };
 }
@@ -56,7 +61,6 @@ export const rule = createRule<keyof typeof errorMessages, Options>(
   meta,
   defaultOptions,
   {
-    ':matches(TSInterfaceBody, TSTypeAliasDeclaration > TSIntersectionType > TSTypeLiteral, TSTypeAliasDeclaration > TSTypeLiteral, TSTypeAliasDeclaration > TSTypeReference:not([typeName.name="Readonly"]) > TSTypeParameterInstantiation > TSIntersectionType > TSTypeLiteral, TSTypeLiteral > TSPropertySignature > TSTypeAnnotation > TSTypeLiteral) > TSMethodSignature':
-      checkTSMethodSignature,
+    TSMethodSignature: checkTSMethodSignature,
   }
 );

--- a/src/rules/no-method-signature.ts
+++ b/src/rules/no-method-signature.ts
@@ -13,13 +13,28 @@ import { inReadonly } from "../util/tree";
 export const name = "no-method-signature" as const;
 
 // The options this rule can take.
-type Options = {};
+type Options = {
+  readonly ignoreIfReadonly: boolean;
+};
 
 // The schema for the rule options.
-const schema: JSONSchema4 = [];
+const schema: JSONSchema4 = [
+  {
+    type: "object",
+    properties: {
+      ignoreIfReadonly: {
+        type: "boolean",
+        default: true,
+      },
+    },
+    additionalProperties: false,
+  },
+];
 
 // The default options for the rule.
-const defaultOptions: Options = {};
+const defaultOptions: Options = {
+  ignoreIfReadonly: true,
+};
 
 // The possible error messages.
 const errorMessages = {
@@ -45,9 +60,10 @@ const meta: RuleMetaData<keyof typeof errorMessages> = {
  */
 function checkTSMethodSignature(
   node: TSESTree.TSMethodSignature,
-  context: RuleContext<keyof typeof errorMessages, Options>
+  context: RuleContext<keyof typeof errorMessages, Options>,
+  { ignoreIfReadonly }: Options
 ): RuleResult<keyof typeof errorMessages, Options> {
-  if (inReadonly(node)) {
+  if (ignoreIfReadonly && inReadonly(node)) {
     return { context, descriptors: [] };
   }
 

--- a/src/rules/no-method-signature.ts
+++ b/src/rules/no-method-signature.ts
@@ -56,6 +56,7 @@ export const rule = createRule<keyof typeof errorMessages, Options>(
   meta,
   defaultOptions,
   {
-    TSMethodSignature: checkTSMethodSignature,
+    ':matches(TSInterfaceBody, TSTypeAliasDeclaration > TSIntersectionType > TSTypeLiteral, TSTypeAliasDeclaration > TSTypeLiteral, TSTypeAliasDeclaration > TSTypeReference:not([typeName.name="Readonly"]) > TSTypeParameterInstantiation > TSIntersectionType > TSTypeLiteral, TSTypeLiteral > TSPropertySignature > TSTypeAnnotation > TSTypeLiteral) > TSMethodSignature':
+      checkTSMethodSignature,
   }
 );

--- a/src/util/typeguard.ts
+++ b/src/util/typeguard.ts
@@ -211,6 +211,12 @@ export function isTSInterfaceBody(
   return node.type === AST_NODE_TYPES.TSInterfaceBody;
 }
 
+export function isTSInterfaceHeritage(
+  node: TSESTree.Node
+): node is TSESTree.TSInterfaceHeritage {
+  return node.type === AST_NODE_TYPES.TSInterfaceHeritage;
+}
+
 export function isTSNullKeyword(
   node: TSESTree.Node
 ): node is TSESTree.TSNullKeyword {

--- a/tests/rules/no-method-signature.test.ts
+++ b/tests/rules/no-method-signature.test.ts
@@ -69,6 +69,17 @@ const valid: ReadonlyArray<ValidTestCase> = [
       }>`,
     optionsSet: [[]],
   },
+  {
+    code: dedent`
+      type Foo = Bar & Readonly<Baz & {
+        readonly nested: {
+          deepNested: Readonly<{
+            methodSignature(): void
+          }>
+        }
+      }>`,
+    optionsSet: [[]],
+  },
 ];
 
 // Invalid test cases.
@@ -132,6 +143,25 @@ const invalid: ReadonlyArray<InvalidTestCase> = [
         type: "TSMethodSignature",
         line: 3,
         column: 5,
+      },
+    ],
+  },
+  {
+    code: dedent`
+      type Foo = Bar & Readonly<Baz & {
+        readonly nested: Readonly<{
+          deepNested: {
+            methodSignature(): void
+          }
+        }>
+      }>`,
+    optionsSet: [[]],
+    errors: [
+      {
+        messageId: "generic",
+        type: "TSMethodSignature",
+        line: 4,
+        column: 7,
       },
     ],
   },

--- a/tests/rules/no-method-signature.test.ts
+++ b/tests/rules/no-method-signature.test.ts
@@ -27,9 +27,46 @@ const valid: ReadonlyArray<ValidTestCase> = [
   },
   {
     code: dedent`
+      interface Foo extends Readonly<{
+        methodSignature(): void
+      }>{}`,
+    optionsSet: [[]],
+  },
+  {
+    code: dedent`
+      interface Foo extends Bar, Readonly<Baz & {
+        methodSignature(): void
+      }>{}`,
+    optionsSet: [[]],
+  },
+  {
+    code: dedent`
       type Foo2 = {
         bar: (a: number, b: string) => number
       }`,
+    optionsSet: [[]],
+  },
+  {
+    code: dedent`
+      type Foo = Readonly<{
+        methodSignature(): void
+      }>`,
+    optionsSet: [[]],
+  },
+  {
+    code: dedent`
+      type Foo = Bar & Readonly<Baz & {
+        methodSignature(): void
+      }>`,
+    optionsSet: [[]],
+  },
+  {
+    code: dedent`
+      type Foo = Bar & Readonly<Baz & {
+        nested: Readonly<{
+          methodSignature(): void
+        }>
+      }>`,
     optionsSet: [[]],
   },
 ];
@@ -63,6 +100,38 @@ const invalid: ReadonlyArray<InvalidTestCase> = [
         type: "TSMethodSignature",
         line: 2,
         column: 3,
+      },
+    ],
+  },
+  {
+    code: dedent`
+      type Foo = Bar & Readonly<Baz> & {
+        methodSignature(): void
+      }`,
+    optionsSet: [[]],
+    errors: [
+      {
+        messageId: "generic",
+        type: "TSMethodSignature",
+        line: 2,
+        column: 3,
+      },
+    ],
+  },
+  {
+    code: dedent`
+      type Foo = Bar & Readonly<Baz & {
+        nested: {
+          methodSignature(): void
+        }
+      }>`,
+    optionsSet: [[]],
+    errors: [
+      {
+        messageId: "generic",
+        type: "TSMethodSignature",
+        line: 3,
+        column: 5,
       },
     ],
   },

--- a/tests/rules/no-method-signature.test.ts
+++ b/tests/rules/no-method-signature.test.ts
@@ -71,13 +71,13 @@ const valid: ReadonlyArray<ValidTestCase> = [
   },
   {
     code: dedent`
-      type Foo = Bar & Readonly<Baz & {
+      interface Foo extends Bar, Readonly<Baz & {
         readonly nested: {
           deepNested: Readonly<{
             methodSignature(): void
           }>
         }
-      }>`,
+      }>{}`,
     optionsSet: [[]],
   },
 ];
@@ -148,13 +148,13 @@ const invalid: ReadonlyArray<InvalidTestCase> = [
   },
   {
     code: dedent`
-      type Foo = Bar & Readonly<Baz & {
+      interface Foo extends Bar, Readonly<Baz & {
         readonly nested: Readonly<{
           deepNested: {
             methodSignature(): void
           }
         }>
-      }>`,
+      }>{}`,
     optionsSet: [[]],
     errors: [
       {

--- a/tests/rules/no-method-signature.test.ts
+++ b/tests/rules/no-method-signature.test.ts
@@ -165,6 +165,25 @@ const invalid: ReadonlyArray<InvalidTestCase> = [
       },
     ],
   },
+  {
+    code: dedent`
+      interface Foo extends Bar, Readonly<Baz & {
+        readonly nested: {
+          deepNested: Readonly<{
+            methodSignature(): void
+          }>
+        }
+      }>{}`,
+    optionsSet: [[{ ignoreIfReadonly: false }]],
+    errors: [
+      {
+        messageId: "generic",
+        type: "TSMethodSignature",
+        line: 4,
+        column: 7,
+      },
+    ],
+  },
 ];
 
 describeTsOnly("TypeScript", () => {


### PR DESCRIPTION
Fixes: #261.