### PR TITLE
fix: get the coorect identifier text of values in object expressions

### DIFF
--- a/src/common/ignore-options.ts
+++ b/src/common/ignore-options.ts
@@ -3,7 +3,12 @@ import escapeRegExp from "escape-string-regexp";
 import type { JSONSchema4 } from "json-schema";
 
 import type { BaseOptions, RuleContext } from "~/util/rule";
-import { inClass, inFunctionBody, inInterface } from "~/util/tree";
+import {
+  getKeyOfValueInObjectExpression,
+  inClass,
+  inFunctionBody,
+  inInterface,
+} from "~/util/tree";
 import {
   hasID,
   hasKey,
@@ -116,35 +121,48 @@ function getNodeIdentifierText(
   node: TSESTree.Node | null | undefined,
   context: RuleContext<string, BaseOptions>
 ): string | undefined {
-  return isDefined(node)
-    ? isIdentifier(node)
-      ? node.name
-      : hasID(node) && isDefined(node.id)
-      ? getNodeIdentifierText(node.id, context)
-      : hasKey(node) && isDefined(node.key)
-      ? getNodeIdentifierText(node.key, context)
-      : isAssignmentExpression(node)
-      ? getNodeIdentifierText(node.left, context)
-      : isMemberExpression(node)
-      ? `${getNodeIdentifierText(node.object, context)}.${getNodeIdentifierText(
-          node.property,
-          context
-        )}`
-      : isThisExpression(node)
-      ? "this"
-      : isUnaryExpression(node)
-      ? getNodeIdentifierText(node.argument, context)
-      : isExpressionStatement(node)
-      ? context.getSourceCode().getText(node)
-      : isTSArrayType(node) ||
-        isTSIndexSignature(node) ||
-        isTSTupleType(node) ||
-        isTSTypeAnnotation(node) ||
-        isTSTypeLiteral(node) ||
-        isTSTypeReference(node)
-      ? getNodeIdentifierText(node.parent, context)
-      : undefined
-    : undefined;
+  if (!isDefined(node)) {
+    return undefined;
+  }
+
+  const identifierText = isIdentifier(node)
+    ? node.name
+    : hasID(node) && isDefined(node.id)
+    ? getNodeIdentifierText(node.id, context)
+    : hasKey(node) && isDefined(node.key)
+    ? getNodeIdentifierText(node.key, context)
+    : isAssignmentExpression(node)
+    ? getNodeIdentifierText(node.left, context)
+    : isMemberExpression(node)
+    ? `${getNodeIdentifierText(node.object, context)}.${getNodeIdentifierText(
+        node.property,
+        context
+      )}`
+    : isThisExpression(node)
+    ? "this"
+    : isUnaryExpression(node)
+    ? getNodeIdentifierText(node.argument, context)
+    : isExpressionStatement(node)
+    ? context.getSourceCode().getText(node)
+    : isTSArrayType(node) ||
+      isTSIndexSignature(node) ||
+      isTSTupleType(node) ||
+      isTSTypeAnnotation(node) ||
+      isTSTypeLiteral(node) ||
+      isTSTypeReference(node)
+    ? getNodeIdentifierText(node.parent, context)
+    : null;
+
+  if (identifierText !== null) {
+    return identifierText;
+  }
+
+  const keyInObjectExpression = getKeyOfValueInObjectExpression(node);
+  if (keyInObjectExpression !== null) {
+    return keyInObjectExpression;
+  }
+
+  return undefined;
 }
 
 /**

--- a/src/util/tree.ts
+++ b/src/util/tree.ts
@@ -10,6 +10,7 @@ import {
   isIdentifier,
   isMemberExpression,
   isMethodDefinition,
+  isObjectExpression,
   isProperty,
   isTSInterfaceBody,
   isTSInterfaceHeritage,
@@ -141,4 +142,37 @@ export function isIIFE(node: TSESTree.Node): boolean {
     isCallExpression(node.parent) &&
     node.parent.callee === node
   );
+}
+
+/**
+ * Get the key the given node is assigned to in its parent ObjectExpression.
+ */
+export function getKeyOfValueInObjectExpression(
+  node: TSESTree.Node
+): string | null {
+  if (!isDefined(node.parent)) {
+    return null;
+  }
+
+  const objectExpression = getAncestorOfType(isObjectExpression, node);
+  if (objectExpression === null) {
+    return null;
+  }
+
+  const objectExpressionProps = objectExpression.properties.filter(
+    (prop) => isProperty(prop) && prop.value === node
+  );
+  if (objectExpressionProps.length !== 1) {
+    return null;
+  }
+
+  const objectExpressionProp = objectExpressionProps[0];
+  if (
+    !isProperty(objectExpressionProp) ||
+    !isIdentifier(objectExpressionProp.key)
+  ) {
+    return null;
+  }
+
+  return objectExpressionProp.key.name;
 }

--- a/src/util/typeguard.ts
+++ b/src/util/typeguard.ts
@@ -180,6 +180,12 @@ export function isNewExpression(
   return node.type === AST_NODE_TYPES.NewExpression;
 }
 
+export function isObjectExpression(
+  node: TSESTree.Node
+): node is TSESTree.ObjectExpression {
+  return node.type === AST_NODE_TYPES.ObjectExpression;
+}
+
 export function isProperty(node: TSESTree.Node): node is TSESTree.Property {
   return node.type === AST_NODE_TYPES.Property;
 }

--- a/tests/rules/functional-parameters/es6/valid.ts
+++ b/tests/rules/functional-parameters/es6/valid.ts
@@ -27,6 +27,16 @@ const tests: ReadonlyArray<ValidTestCase> = [
     `,
     optionsSet: [[{ ignorePattern: "^foo" }]],
   },
+  {
+    code: dedent`
+      const baz = {
+        foo(...bar) {
+          console.log(bar);
+        }
+      }
+    `,
+    optionsSet: [[{ ignorePattern: "^foo" }]],
+  },
 ];
 
 export default tests;


### PR DESCRIPTION
Fixes #282 