### PR TITLE
docs: add example of deleting an array element

### DIFF
--- a/docs/rules/immutable-data.md
+++ b/docs/rules/immutable-data.md
@@ -31,6 +31,7 @@ const arr = [0, 1, 2];
 
 arr[0] = 4; // <- Modifying an array is not allowed.
 arr.length = 1; // <- Modifying an array is not allowed.
+delete arr[1]; // <- Modifying an existing array is not allowed.
 arr.push(3); // <- Modifying an array is not allowed.
 ```
 


### PR DESCRIPTION
Reading this doc made me think it wasn't including the situation where `delete` was used to remove an array element - which does not update the array's length which is often unexpected. However, trying it, it does flag this as an error, so I think it would be useful to have it in the docs.

```
  3:1  error  Modifying an existing object/array is not allowed  functional/immutable-data
```

Maybe it could use to more explanation, but I'm not sure where that would do in this document.

Fixes: #(Issue Number)

# Proposed Changes

<!-- Describe the changes and rationale behind them. -->
