### PR TITLE
fix: typos and tighten a sentence

### DIFF
--- a/docs/rules/no-conditional-statement.md
+++ b/docs/rules/no-conditional-statement.md
@@ -1,6 +1,6 @@
 # Disallow conditional statements (no-conditional-statement)
 
-This rule disallows conditional statements such as if and switch.
+This rule disallows conditional statements such as `if` and `switch`.
 
 ## Rule Details
 
@@ -68,7 +68,7 @@ const defaults = {
 
 #### `true`
 
-The optional allows conditional statements but only if all defined branches end with a return statement or other terminal.
+Allows conditional statements but only if all defined branches end with a return statement or other terminal.
 This allows early escapes to be used.
 
 ```js
@@ -83,8 +83,8 @@ function foo(error, data) {
 
 #### `"ifExhaustive"`
 
-This will only allow conditional statements to exists if every case is taken it to account and each has a return statement or other terminal.
-In other works, every if must have an else and every switch must have a default case.
+This will only allow conditional statements to exist if every case is taken into account and each has a return statement or other terminal.
+In other words, every `if` must have an `else` and every `switch` must have a default case.
 This allows conditional statements to be used like [do expressions](https://github.com/tc39/proposal-do-expressions).
 
 ```js


### PR DESCRIPTION
# Proposed Changes

- Minor typos helps the documentation flow.
- Remove implied reference to the option being described, helps readability. Less text more clarity.
- Wrap reserved keywords in code backticks.