### PR TITLE
fix(prefer-tacit): assign callee to a new variable when autofixing function declarations

### DIFF
--- a/tests/rules/prefer-tacit/ts/invalid.ts
+++ b/tests/rules/prefer-tacit/ts/invalid.ts
@@ -23,6 +23,45 @@ const tests: ReadonlyArray<InvalidTestCase> = [
       },
     ],
   },
+  {
+    code: dedent`
+      function f(x) {}
+      function foo(x) { return f(x); }
+    `,
+    optionsSet: [[]],
+    output: dedent`
+      function f(x) {}
+      const foo = f;
+    `,
+    errors: [
+      {
+        messageId: "generic",
+        type: "FunctionDeclaration",
+        line: 2,
+        column: 1,
+      },
+    ],
+  },
+  // FunctionDeclaration without name
+  {
+    code: dedent`
+      function f(x) {}
+      export default function (x) { return f(x); }
+    `,
+    optionsSet: [[]],
+    output: dedent`
+      function f(x) {}
+      export default function (x) { return f(x); }
+    `,
+    errors: [
+      {
+        messageId: "generic",
+        type: "FunctionDeclaration",
+        line: 2,
+        column: 16,
+      },
+    ],
+  },
   // FunctionExpression.
   {
     code: dedent`


### PR DESCRIPTION
Currently the following code:

```ts
function f(x) {}
function foo(x) { return f(x); }
```

gets changed to

```ts
function f(x) {}
f;
```

via the provided autofix.

This PR provides a better autofix for named function declarations, so it will be fixed to:

```ts
function f(x) {}
const foo = f;
```

There is one exception for function declarations without a name, for example when used within default exports. In this case no autofix is provided.