### PR TITLE
fix: let user immutability overrides win over defaults

### DIFF
--- a/docs/rules/settings/immutability.md
+++ b/docs/rules/settings/immutability.md
@@ -11,6 +11,13 @@ For details see [the overrides
 section](https://github.com/RebeccaStevens/is-immutable-type#overrides) of
 [is-immutable-type](https://www.npmjs.com/package/is-immutable-type).
 
+### Resolution order
+
+When looking up an override for a type, the first matching entry wins. User
+overrides are placed before the built-in defaults, so a user-defined override
+for a type that also has a default (e.g. `Date`) takes precedence. Set
+`keepDefault: false` to drop the built-in defaults entirely.
+
 ### Example of configuring immutability overrides
 
 In this example, we are configuring

--- a/src/settings/immutability.ts
+++ b/src/settings/immutability.ts
@@ -92,5 +92,5 @@ function loadImmutabilityOverrides(
 
   const keepDefault = Array.isArray(overridesSetting) || overridesSetting.keepDefault !== false;
 
-  return keepDefault ? [...getDefaultImmutabilityOverrides(), ...upgraded] : upgraded;
+  return keepDefault ? [...upgraded, ...getDefaultImmutabilityOverrides()] : upgraded;
 }


### PR DESCRIPTION
User-defined entries in `settings.immutability.overrides` were prepended after the built-in defaults, so `getOverride`'s first-match lookup always returned the default — making user overrides for types like `Date` silently unreachable. This swaps the concat order so user overrides take precedence, and documents the resolution rule.

I'd consider this a bug fix, but it could also be viewed as a breaking change for anyone whose config happened to rely on the default winning over a same-typed user entry.
