### PR TITLE
feat: add option `ignoreTypePattern` to `type-declaration-immutability`

### DIFF
--- a/docs/rules/type-declaration-immutability.md
+++ b/docs/rules/type-declaration-immutability.md
@@ -95,6 +95,7 @@ type Options = {
   }>;
   ignoreInterfaces: boolean;
   ignoreIdentifierPattern: string[] | string;
+  ignoreTypePattern: string[] | string;
 };
 ```
 
@@ -206,3 +207,25 @@ A boolean to specify whether interfaces should be exempt from these rules.
 
 This option takes a RegExp string or an array of RegExp strings.
 It allows for the ability to ignore violations based on a type's name.
+
+### `ignoreTypePattern`
+
+This option takes a `RegExp` string or an array of `RegExp` strings.
+It allows for the ability to ignore violations based on the type alias's
+right-hand side (as written, with whitespace removed).
+
+This is useful for skipping aliases whose right-hand side is purely a
+named-reference composition that no consumer-side annotation can make
+`ReadonlyShallow` — for example a union of third-party class types, a
+utility-type composition, or a namespaced inferred type:
+
+<!-- eslint-skip -->
+
+```ts
+type UnderlyingServer = Http2SecureServer | Http2Server | Server;
+type UploadResult = Awaited<ReturnType<Uploader["upload"]>>;
+```
+
+This option only applies to type alias declarations. Interfaces have no
+right-hand side, so it has no effect on them; use `ignoreInterfaces` or
+`ignoreIdentifierPattern` for those.

--- a/src/options/ignore.ts
+++ b/src/options/ignore.ts
@@ -53,6 +53,25 @@ export const ignoreCodePatternOptionSchema: JSONSchema4ObjectSchema["properties"
 };
 
 /**
+ * The option to ignore types matching a pattern.
+ */
+export type IgnoreTypePatternOption = Readonly<{
+  ignoreTypePattern?: ReadonlyArray<string> | string;
+}>;
+
+/**
+ * The schema for the option to ignore types matching a pattern.
+ */
+export const ignoreTypePatternOptionSchema: JSONSchema4ObjectSchema["properties"] = {
+  ignoreTypePattern: {
+    type: ["string", "array"],
+    items: {
+      type: "string",
+    },
+  },
+};
+
+/**
  * The option to ignore accessor patterns.
  */
 export type IgnoreAccessorPatternOption = Readonly<{
@@ -245,5 +264,21 @@ export function shouldIgnorePattern(
       texts.every((text) => shouldIgnoreViaAccessorPattern(text, ignoreAccessorPattern))) ||
     // Ignore if ignoreCodePattern is set and a code pattern matches.
     (ignoreCodePattern !== undefined && shouldIgnoreViaPattern(getNodeCode(node, context), ignoreCodePattern))
+  );
+}
+
+/**
+ * Should the given type node be allowed based off the IgnoreTypePatternOption?
+ *
+ * The pattern is matched against the type's source text with whitespace removed.
+ */
+export function shouldIgnoreTypePattern(
+  node: TSESTree.Node,
+  context: Readonly<RuleContext<string, BaseOptions>>,
+  ignoreTypePattern: Readonly<Partial<IgnoreTypePatternOption>["ignoreTypePattern"]>,
+): boolean {
+  return (
+    ignoreTypePattern !== undefined &&
+    shouldIgnoreViaPattern(getNodeCode(node, context).replaceAll(/\s+/gu, ""), ignoreTypePattern)
   );
 }

--- a/src/rules/type-declaration-immutability.ts
+++ b/src/rules/type-declaration-immutability.ts
@@ -6,8 +6,11 @@ import { Immutability } from "is-immutable-type";
 
 import {
   type IgnoreIdentifierPatternOption,
+  type IgnoreTypePatternOption,
   ignoreIdentifierPatternOptionSchema,
+  ignoreTypePatternOptionSchema,
   shouldIgnorePattern,
+  shouldIgnoreTypePattern,
 } from "#/options";
 import { getNodeIdentifierTexts, ruleNameScope } from "#/utils/misc";
 import type { ESTypeDeclaration } from "#/utils/node-types";
@@ -59,16 +62,17 @@ type SuggestionsConfig = FixerConfig[];
  * The options this rule can take.
  */
 type RawOptions = [
-  IgnoreIdentifierPatternOption & {
-    rules: Array<{
-      identifiers: string | string[];
-      immutability: Exclude<Immutability | keyof typeof Immutability, "Unknown">;
-      comparator?: RuleEnforcementComparator | keyof typeof RuleEnforcementComparator;
-      fixer?: FixerConfigRaw | FixerConfigRaw[] | false;
-      suggestions?: FixerConfigRaw[] | false;
-    }>;
-    ignoreInterfaces: boolean;
-  },
+  IgnoreIdentifierPatternOption &
+    IgnoreTypePatternOption & {
+      rules: Array<{
+        identifiers: string | string[];
+        immutability: Exclude<Immutability | keyof typeof Immutability, "Unknown">;
+        comparator?: RuleEnforcementComparator | keyof typeof RuleEnforcementComparator;
+        fixer?: FixerConfigRaw | FixerConfigRaw[] | false;
+        suggestions?: FixerConfigRaw[] | false;
+      }>;
+      ignoreInterfaces: boolean;
+    },
 ];
 
 /**
@@ -128,7 +132,7 @@ const suggestionsSchema: JSONSchema4 = {
 const schema: JSONSchema4[] = [
   {
     type: "object",
-    properties: deepmerge(ignoreIdentifierPatternOptionSchema, {
+    properties: deepmerge(ignoreIdentifierPatternOptionSchema, ignoreTypePatternOptionSchema, {
       rules: {
         type: "array",
         items: {
@@ -409,10 +413,11 @@ function checkTypeDeclaration(
   options: Readonly<RawOptions>,
 ): RuleResult<keyof typeof errorMessages, RawOptions> {
   const [optionsObject] = options;
-  const { ignoreInterfaces, ignoreIdentifierPattern } = optionsObject;
+  const { ignoreInterfaces, ignoreIdentifierPattern, ignoreTypePattern } = optionsObject;
   if (
     shouldIgnorePattern(node, context, ignoreIdentifierPattern) ||
-    (ignoreInterfaces && isTSInterfaceDeclaration(node))
+    (ignoreInterfaces && isTSInterfaceDeclaration(node)) ||
+    (!isTSInterfaceDeclaration(node) && shouldIgnoreTypePattern(node.typeAnnotation, context, ignoreTypePattern))
   ) {
     return {
       context,

--- a/tests/rules/__snapshots__/type-declaration-immutability.test.ts.snap
+++ b/tests/rules/__snapshots__/type-declaration-immutability.test.ts.snap
@@ -1,5 +1,83 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`type-declaration-immutability > typescript > ignoreTypePattern > still reports object literals and array types 1`] = `
+{
+  "fixed": false,
+  "messages": [
+    {
+      "column": 6,
+      "endColumn": 17,
+      "endLine": 1,
+      "line": 1,
+      "message": "This type is declare to have an immutability of at least "Immutable" (actual: "Mutable").",
+      "messageId": "AtLeast",
+      "nodeType": "Identifier",
+      "ruleId": "type-declaration-immutability",
+      "severity": 2,
+    },
+  ],
+  "output": "type ReadonlyFoo = { a: string };",
+  "steps": [
+    {
+      "fixed": false,
+      "messages": [
+        {
+          "column": 6,
+          "endColumn": 17,
+          "endLine": 1,
+          "line": 1,
+          "message": "This type is declare to have an immutability of at least "Immutable" (actual: "Mutable").",
+          "messageId": "AtLeast",
+          "nodeType": "Identifier",
+          "ruleId": "rule-to-test/type-declaration-immutability",
+          "severity": 2,
+        },
+      ],
+      "output": "type ReadonlyFoo = { a: string };",
+    },
+  ],
+}
+`;
+
+exports[`type-declaration-immutability > typescript > ignoreTypePattern > still reports object literals and array types 2`] = `
+{
+  "fixed": false,
+  "messages": [
+    {
+      "column": 6,
+      "endColumn": 17,
+      "endLine": 1,
+      "line": 1,
+      "message": "This type is declare to have an immutability of at least "Immutable" (actual: "Mutable").",
+      "messageId": "AtLeast",
+      "nodeType": "Identifier",
+      "ruleId": "type-declaration-immutability",
+      "severity": 2,
+    },
+  ],
+  "output": "type ReadonlyFoo = string[];",
+  "steps": [
+    {
+      "fixed": false,
+      "messages": [
+        {
+          "column": 6,
+          "endColumn": 17,
+          "endLine": 1,
+          "line": 1,
+          "message": "This type is declare to have an immutability of at least "Immutable" (actual: "Mutable").",
+          "messageId": "AtLeast",
+          "nodeType": "Identifier",
+          "ruleId": "rule-to-test/type-declaration-immutability",
+          "severity": 2,
+        },
+      ],
+      "output": "type ReadonlyFoo = string[];",
+    },
+  ],
+}
+`;
+
 exports[`type-declaration-immutability > typescript > reports invalid deep arrays 1`] = `
 {
   "fixed": false,

--- a/tests/rules/type-declaration-immutability.test.ts
+++ b/tests/rules/type-declaration-immutability.test.ts
@@ -340,6 +340,81 @@ describe(name, () => {
       });
     });
 
+    describe("ignoreTypePattern", () => {
+      it("doesn't report a union of named references", async () => {
+        await valid({
+          code: "type ReadonlyServer = Http2SecureServer | Http2Server | Server;",
+          options: [
+            {
+              ignoreTypePattern: "^[A-Za-z0-9.]+(\\|[A-Za-z0-9.]+)+$",
+            },
+          ],
+        });
+      });
+
+      it("doesn't report a utility-type composition over a named reference", async () => {
+        await valid({
+          code: "type ReadonlyUploadResult = Awaited<ReturnType<Uploader['upload']>>;",
+          options: [
+            {
+              ignoreTypePattern: "^Awaited<",
+            },
+          ],
+        });
+      });
+
+      it("doesn't report a namespaced reference", async () => {
+        await valid({
+          code: "type ReadonlyInferredValue = z.infer<typeof schema>;",
+          options: [
+            {
+              ignoreTypePattern: "^z\\.infer<",
+            },
+          ],
+        });
+      });
+
+      it("still reports object literals and array types", async () => {
+        const invalidResult1 = await invalid({
+          code: "type ReadonlyFoo = { a: string };",
+          options: [
+            {
+              ignoreTypePattern: "^z\\.infer<",
+            },
+          ],
+          errors: ["AtLeast"],
+        });
+        expect(invalidResult1.result).toMatchSnapshot();
+
+        const invalidResult2 = await invalid({
+          code: "type ReadonlyFoo = string[];",
+          options: [
+            {
+              ignoreTypePattern: "^z\\.infer<",
+            },
+          ],
+          errors: ["AtLeast"],
+        });
+        expect(invalidResult2.result).toMatchSnapshot();
+      });
+
+      it("has no effect on interfaces", async () => {
+        await invalid({
+          code: dedent`
+            interface ReadonlyFoo {
+              foo: number;
+            }
+          `,
+          options: [
+            {
+              ignoreTypePattern: ".*",
+            },
+          ],
+          errors: ["AtLeast"],
+        });
+      });
+    });
+
     it("respects override settings", async () => {
       await valid({
         code: dedent`


### PR DESCRIPTION
Mirror the `ignoreTypePattern` option that already exists on `prefer-immutable-types` onto `type-declaration-immutability`. The pattern is matched against a type alias's right-hand side source text (whitespace removed) and, when it matches, the rule is skipped before immutability is computed.

This lets presets exempt aliases whose right-hand side is a pure named-reference composition that no consumer-side annotation can make `ReadonlyShallow` — unions of third-party class types, utility-type compositions, or namespaced inferred types. Interfaces have no right-hand side, so the option applies only to `TSTypeAliasDeclaration`; `TSInterfaceDeclaration` behavior is unchanged.